### PR TITLE
Update IPOPT implementation to new HeatExchange names and NLP hook

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ UnitfulMoles = "999f2bd7-36bf-5ba7-9bc1-c9473aa75374"
 [sources]
 BiophysicalGeometry = {rev = "characteristic-dimension-options", url = "https://github.com/BiophysicalEcology/BiophysicalGeometry.jl"}
 FluidProperties = {rev = "main", url = "https://github.com/BiophysicalEcology/FluidProperties.jl"}
-#HeatExchange = {rev = "main", url = "https://github.com/BiophysicalEcology/HeatExchange.jl"}
+HeatExchange = {rev = "main", url = "https://github.com/BiophysicalEcology/HeatExchange.jl"}
 
 [compat]
 Aqua = "0.8"

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ UnitfulMoles = "999f2bd7-36bf-5ba7-9bc1-c9473aa75374"
 [sources]
 BiophysicalGeometry = {rev = "characteristic-dimension-options", url = "https://github.com/BiophysicalEcology/BiophysicalGeometry.jl"}
 FluidProperties = {rev = "main", url = "https://github.com/BiophysicalEcology/FluidProperties.jl"}
-HeatExchange = {rev = "main", url = "https://github.com/BiophysicalEcology/HeatExchange.jl"}
+#HeatExchange = {rev = "main", url = "https://github.com/BiophysicalEcology/HeatExchange.jl"}
 
 [compat]
 Aqua = "0.8"

--- a/Project.toml
+++ b/Project.toml
@@ -21,9 +21,9 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulMoles = "999f2bd7-36bf-5ba7-9bc1-c9473aa75374"
 
 [sources]
-BiophysicalGeometry = {rev = "rename-to-aspect_ratio", url = "https://github.com/BiophysicalEcology/BiophysicalGeometry.jl"}
+BiophysicalGeometry = {rev = "characteristic-dimension-options", url = "https://github.com/BiophysicalEcology/BiophysicalGeometry.jl"}
 FluidProperties = {rev = "main", url = "https://github.com/BiophysicalEcology/FluidProperties.jl"}
-HeatExchange = {rev = "IPOPT-preparation", url = "https://github.com/BiophysicalEcology/HeatExchange.jl"}
+HeatExchange = {rev = "main", url = "https://github.com/BiophysicalEcology/HeatExchange.jl"}
 
 [compat]
 Aqua = "0.8"

--- a/docs/ectotherm_thermoregulation_logic.md
+++ b/docs/ectotherm_thermoregulation_logic.md
@@ -64,11 +64,11 @@ far this hour). Key fields:
 | `height` | `SteppedParameter` — current/reference height node | CLIMB height node |
 | `absorptivity` | `SteppedParameter` — current/min(ref)/max alpha | alpha_min / alpha_max |
 | `pant_rate` | `SteppedParameter` — current/max pant multiplier | pantmax |
-| `T_target` | `SteppedParameter` — current/max preferred temperature | TPREF / T_F_max |
-| `T_active_min/max` | Foraging temperature range | TMINPR / TMAXPR (T_F_min / T_F_max) |
-| `T_bask_min` | Minimum basking temperature | TBASK (T_B_min) |
-| `T_critical_min/max` | Lethal thermal limits | CTMIN / CTMAX |
-| `T_emerge_min` | Minimum soil temperature to emerge from underground retreat | TEMERGE (T_RB_min) |
+| `target_temperature` | `SteppedParameter` — current/max preferred temperature | TPREF / T_F_max |
+| `active_temperature_min/max` | Foraging temperature range | TMINPR / TMAXPR (T_F_min / T_F_max) |
+| `basking_temperature_min` | Minimum basking temperature | TBASK (T_B_min) |
+| `critical_temperature_min/max` | Lethal thermal limits | CTMIN / CTMAX |
+| `emerge_temperature_min` | Minimum soil temperature to emerge from underground retreat | TEMERGE (T_RB_min) |
 | `can_*` | Boolean capability flags | BURROW / CLIMB / SHADE / postur / panting flags |
 | `sun_orientation` | Current posture angle (°): 45=Intermediate, 90=NormalToSun, 0=ParallelToSun | postur |
 | `pressed_to_ground` | Current ground-contact state | pct_cond |
@@ -91,7 +91,7 @@ At the start of every hour, `reset_position` sets all stepped parameters back to
 - `height.current` → `height.reference` (= 1, lowest node)
 - `absorptivity.current` → `absorptivity.max` (darkest = maximum solar gain, ready to lighten if hot)
 - `pant_rate.current` → `pant_rate.reference` (= 1.0, no panting)
-- `T_target.current` → `T_target.reference` (starting preferred temperature)
+- `target_temperature.current` → `target_temperature.reference` (starting preferred temperature)
 - `sun_orientation` → 45.0 (Intermediate, neutral foraging posture)
 - `pressed_to_ground` → false
 
@@ -148,7 +148,7 @@ The underground blend factor (which soil temperature profile to use) is determin
 |---|---|---|
 | `MinShadeOnly()` | 0.0 (always min-shade soil) | 0 |
 | `MaxShadeOnly()` | 1.0 (always max-shade soil) | 2 |
-| `AdaptiveBurrowShade()` | 1.0 if min-shade soil at shallowest node is outside [T_crit_min, T_active_max], else 0.0 | 1 |
+| `AdaptiveBurrowShade()` | 1.0 if min-shade soil at shallowest node is outside [critical_temperature_min, active_temperature_max], else 0.0 | 1 |
 
 After position is determined, `interpolate_environment` builds the `EnvironmentalVars` and
 `_build_ectotherm_output` is called and **returned immediately** (no further thermoregulation).
@@ -163,7 +163,7 @@ The soil temperature at the previous-step depth is computed. The animal stays un
 
 **Condition A — Too cold to emerge:**
 ```
-soil_temperature_at_depth < T_emerge_min
+soil_temperature_at_depth < emerge_temperature_min
 ```
 
 **Condition B — No emergence signal from soil temperature** (mirrors ECTOTHERM.f lines 2218–2244):
@@ -199,24 +199,24 @@ Then the iteration loop runs up to `max_iterations` times. Each iteration:
 ### Body temperature solver
 
 `solve_body_temperature` calls `zbrent` (Brent's method, ported from `ZBRENT.f`) to find the root
-of `ectotherm(T, organism, e).Q_bal` on the interval `[273.15 K, 343.15 K]` (0–70°C). If the
-solver fails (e.g., no root in bracket), it returns `T_air` as a fallback.
+of `ectotherm(T, organism, e).heat_balance` on the interval `[273.15 K, 343.15 K]` (0–70°C). If the
+solver fails (e.g., no root in bracket), it returns `air_temperature` as a fallback.
 
 ### Acceptance (loop exit) condition
 
 ```
-T_active_min ≤ core_temperature ≤ T_target.current  →  break
+active_temperature_min ≤ core_temperature ≤ target_temperature.current  →  break
 ```
 
 **Special case — revert perpendicular→intermediate (NicheMapR THERMO.f phase 2, first sub-case):**
 If `can_solar_orient = true` and the organism is fully perpendicular (`sun_orientation = 90.0`)
-and `core_temperature` is now in `[T_active_min, T_target]`, orient back to `Intermediate()` first,
+and `core_temperature` is now in `[active_temperature_min, target_temperature]`, orient back to `Intermediate()` first,
 recompute `core_temperature`, then break. This ensures the animal does not remain in a basking
 posture once it has warmed to its target.
 
 ---
 
-### Too-hot branch (`core_temperature > T_target.current`)
+### Too-hot branch (`core_temperature > target_temperature.current`)
 
 Behaviours are tried in strict priority order. Only the **first applicable** one fires per iteration.
 
@@ -228,7 +228,7 @@ to the shade-seeking priority below in the **same** iteration (no `break`, no `c
 |---|---|---|---|
 | 1 | `can_change_absorptivity` and `absorptivity.current > absorptivity.reference` | `lighten` | Decrease dorsal absorptivity by one step toward `absorptivity_min` |
 | 2 | `can_seek_shade` and `shade.current < shade.max` | `seek_shade` | Increase shade by `shade.step` |
-| 3 | `T_target.current < T_target.max` | `increment_T_target` | Raise tolerance threshold by one step toward `T_active_max` |
+| 3 | `target_temperature.current < target_temperature.max` | `increment_target_temperature` | Raise tolerance threshold by one step toward `active_temperature_max` |
 | 4 | `can_climb` and `height.current < height.max` | `climb` | Move up one height node (cooler, windier air) |
 | 5 | `can_pant` and `pant_rate.current < pant_rate.max` | `pant` | Increase pant multiplier by one step |
 | 6 | `can_retreat_underground` | `select_depth` then **break** | Burrow underground; exit loop |
@@ -236,10 +236,10 @@ to the shade-seeking priority below in the **same** iteration (no `break`, no `c
 
 **Notes:**
 - Both `lighten` and `darken` update both `body_absorptivity_ventral` and `body_absorptivity_ventral`.
-- `increment_T_target` mirrors NicheMapR's TPREF incrementing: the animal tolerates getting
-  hotter before triggering shade-seeking. Once `T_target.current = T_active_max`, shade-seeking
-  begins. This means shade-seeking in the model starts only when the animal is above `T_active_max`,
-  not above the initial `T_target`.
+- `increment_target_temperature` mirrors NicheMapR's TPREF incrementing: the animal tolerates getting
+  hotter before triggering shade-seeking. Once `target_temperature.current = active_temperature_max`, shade-seeking
+  begins. This means shade-seeking in the model starts only when the animal is above `active_temperature_max`,
+  not above the initial `target_temperature`.
 - `climb` moves to higher, typically cooler and windier, air layers. Shade is **not** reset when climbing.
 - When retreating underground (priority 6), `_underground_blend_factor` is computed, `select_depth`
   finds the best node, `interpolate_environment` is called, then the loop **breaks** immediately
@@ -247,7 +247,7 @@ to the shade-seeking priority below in the **same** iteration (no `break`, no `c
 
 ---
 
-### Too-cold branch (`core_temperature < T_bask_min`)
+### Too-cold branch (`core_temperature < basking_temperature_min`)
 
 | Priority | Condition | Behaviour | Effect |
 |---|---|---|---|
@@ -256,8 +256,8 @@ to the shade-seeking priority below in the **same** iteration (no `break`, no `c
 | 3 | `can_press_to_ground` and `!pressed_to_ground` | `press_to_ground` | Record ground contact (conduction fraction from organism physiology) |
 | 4 | zenith < 90° (daytime) and `shade.current > shade.reference` | `avoid_shade` | Decrease shade by one step toward minimum |
 | 5 | `can_seek_shade` and zenith ≥ 90° (night) and `shade.current < shade.max` | `seek_shade` | At night, seek shade to reduce longwave cooling to cold sky |
-| 6 | `can_climb` and `core_temperature < T_critical_min` and `height.current < height.max` | `climb` | Emergency climb above critically cold layer |
-| 7 | `can_retreat_underground` | conditional `select_depth` then **break** | Retreat if `core_temperature < T_critical_min` (emergency) or underground is warmer than air |
+| 6 | `can_climb` and `core_temperature < critical_temperature_min` and `height.current < height.max` | `climb` | Emergency climb above critically cold layer |
+| 7 | `can_retreat_underground` | conditional `select_depth` then **break** | Retreat if `core_temperature < critical_temperature_min` (emergency) or underground is warmer than air |
 | fallback | — | **break** | No options left |
 
 **Notes:**
@@ -266,17 +266,17 @@ to the shade-seeking priority below in the **same** iteration (no `break`, no `c
   pressing to ground has no thermal effect (though it is still recorded in the output).
 - Night shade-seeking (priority 5) is the reverse of daytime shade-seeking: the sky is colder than
   vegetation at night, so moving under cover reduces longwave radiative loss.
-- Underground retreat (priority 7) is **conditional**: the animal only retreats if `Tb < T_critical_min`
+- Underground retreat (priority 7) is **conditional**: the animal only retreats if `Tb < critical_temperature_min`
   **or** if any accessible soil node is warmer than above-ground air. In contrast to the too-hot case,
   the loop does not `break` immediately after the condition check — it breaks regardless of whether
   it actually moved (both paths converge to `break`).
 
 ---
 
-### Basking range (`T_bask_min ≤ core_temperature < T_active_min`)
+### Basking range (`basking_temperature_min ≤ core_temperature < active_temperature_min`)
 
 ```julia
-if limits.can_solar_orient && limits.sun_orientation < 90.0 && core_temperature < T_active_min
+if limits.can_solar_orient && limits.sun_orientation < 90.0 && core_temperature < active_temperature_min
     orient_perpendicular(...)
 else
     break
@@ -316,9 +316,9 @@ After the loop exits:
 4. Converts `depth_node` and `height_node` to physical depths/heights using `available_environments.depths`
    and `available_environments.heights`.
 5. **Activity state classification** (mirrors NicheMapR ACT column):
-   - `Resting()` (ACT=0): not in active period, or underground, or `core_temperature < T_bask_min` or `core_temperature > T_active_max`
-   - `Basking()` (ACT=1): `T_bask_min ≤ core_temperature < T_active_min`
-   - `Active()` (ACT=2): `T_active_min ≤ core_temperature ≤ T_active_max`
+   - `Resting()` (ACT=0): not in active period, or underground, or `core_temperature < basking_temperature_min` or `core_temperature > active_temperature_max`
+   - `Basking()` (ACT=1): `basking_temperature_min ≤ core_temperature < active_temperature_min`
+   - `Active()` (ACT=2): `active_temperature_min ≤ core_temperature ≤ active_temperature_max`
 
 ---
 
@@ -351,7 +351,7 @@ humidity at the current height node. Solar radiation is passed pre-shade (HeatEx
 `(1 - shade)` internally). Relative humidity conserves actual vapour pressure at min-shade
 reference conditions then recomputes RH at blended temperature (ABOVEGROUND.f WETAIR approach).
 
-**Below-ground:** Sets `T_air = T_sky = T_substrate = T_ground = T_soil` at the chosen node,
+**Below-ground:** Sets `air_temperature = sky_temperature = substrate_temperature = ground_temperature = soil_temperature` at the chosen node,
 wind = 0.01 m/s, `global_radiation = 0`. Underground blend factor is determined by
 `burrow_shade_mode` (binary: 0.0 or 1.0, not a linear blend).
 
@@ -361,15 +361,15 @@ Iterates soil nodes from `depth_min_underground` to `depth.max`. Returns the **s
 where:
 
 ```
-T_critical_min < T_soil < T_critical_max - (T_critical_max - T_active_max)/2
+critical_temperature_min < soil_temperature < critical_temperature_max - (critical_temperature_max - active_temperature_max)/2
 ```
 
 If no node satisfies the condition, falls back to the deepest available node.
 
 ### `solve_body_temperature`
 
-Calls `zbrent` (Brent's method, tolerance 1e-3 K) on `ectotherm(T, organism, e).Q_bal` bracketed
-between 273.15 K and 343.15 K. Returns `T_air` as fallback if root-finding fails.
+Calls `zbrent` (Brent's method, tolerance 1e-3 K) on `ectotherm(T, organism, e).heat_balance` bracketed
+between 273.15 K and 343.15 K. Returns `air_temperature` as fallback if root-finding fails.
 
 ### Behaviour functions (all in `thermoregulation.jl`)
 
@@ -383,7 +383,7 @@ returns updated `(limits, organism)` or just `limits`. All updates use `@set` (S
 | `darken(organism, limits)` | Increase `body_absorptivity_dorsal` and `body_absorptivity_ventral` by `absorptivity.step` |
 | `seek_shade(limits)` | Increase `shade.current` by `shade.step` |
 | `avoid_shade(limits)` | Decrease `shade.current` by `shade.step` |
-| `increment_T_target(limits)` | Increase `T_target.current` by `T_target.step` |
+| `increment_target_temperature(limits)` | Increase `target_temperature.current` by `target_temperature.step` |
 | `climb(limits)` | Increase `height.current` by `height.step` |
 | `descend(limits)` | Increase `depth.current` by `depth.step` (not called in main loop) |
 | `orient_parallel(organism, limits)` | Set `ParallelToSun()`, `sun_orientation=0.0`, update `A_silhouette` |
@@ -411,24 +411,24 @@ Each hour:
   │    YES
   │    │
   │    ├─ previous_depth > 1? (was underground)
-  │    │    YES → soil_temperature < T_emerge_min OR emerge_signal not met?
+  │    │    YES → soil_temperature < emerge_temperature_min OR emerge_signal not met?
   │    │              YES → select_depth() → interpolate() → _build_output(active=false) → RETURN
   │    │              NO  → continue (emerge)
   │    │
   │    └─ Above-ground thermoregulation loop (max_iterations):
   │         │
   │         ├─ [revert perpendicular → intermediate if core_temperature now in acceptance window] → break
-  │         ├─ T_active_min ≤ core_temperature ≤ T_target? → break
+  │         ├─ active_temperature_min ≤ core_temperature ≤ target_temperature? → break
   │         │
-  │         ├─ core_temperature > T_target? (too hot)
+  │         ├─ core_temperature > target_temperature? (too hot)
   │         │    [revert perpendicular if applicable, fall through]
-  │         │    lighten → seek_shade → increment_T_target → climb → pant → select_depth+break → break
+  │         │    lighten → seek_shade → increment_target_temperature → climb → pant → select_depth+break → break
   │         │
-  │         ├─ core_temperature < T_bask_min? (too cold)
+  │         ├─ core_temperature < basking_temperature_min? (too cold)
   │         │    darken → orient_perpendicular → press_to_ground → avoid_shade →
   │         │    night-seek_shade → climb(CT_min) → select_depth+break → break
   │         │
-  │         └─ T_bask_min ≤ core_temperature < T_active_min? (basking)
+  │         └─ basking_temperature_min ≤ core_temperature < active_temperature_min? (basking)
   │              orient_perpendicular → break
   │
   └─ _build_ectotherm_output() → RETURN

--- a/docs/ipopt_endotherm_thermoregulation.md
+++ b/docs/ipopt_endotherm_thermoregulation.md
@@ -1,10 +1,9 @@
 # IPOPT-Based Endotherm Thermoregulation
 
 **Source files:**
-- `src/endotherm/thermoregulation/ipopt.jl` — NLP formulation, solver setup, output assembly (branch: `IPOPT-implementation`)
-- `src/endotherm/thermoregulation/heatexchange.jl` — interim copy of helpers to be moved into `HeatExchange.jl`
+- `src/endotherm/thermoregulation/ipopt.jl` — NLP formulation, solver setup, output assembly
 - `src/endotherm/endotherm_traits.jl` — `ThermoregulationLimits` struct and penalty fields
-- `HeatExchange.jl/src/endotherm/heat_balance.jl` — `heat_balance` function used as NLP constraints (branch: `IPOPT-preparation`)
+- `HeatExchange.jl/src/nlp_interface.jl` — `nlp_pack`, `nlp_residuals`, `nlp_assemble_output` functions used by the NLP solver
 
 ---
 
@@ -44,9 +43,9 @@ Following standard control theory, the nine NLP decision variables are split int
 **State variables (x)** — outcomes determined by the effectors and the heat balance:
 | Variable | Description |
 |---|---|
-| Core temperature | `T_core` (K) |
-| Skin temperature | `T_skin` (K) |
-| Insulation surface temperature | `T_insulation` (K) |
+| Core temperature | `core_temperature` (K) |
+| Skin temperature | `skin_temperature` (K) |
+| Insulation surface temperature | `insulation_temperature` (K) |
 
 In principle, state variables are fully determined by the effectors via the heat balance
 constraints. Including them explicitly as NLP variables (with equality constraints to enforce
@@ -54,14 +53,27 @@ consistency) improves numerical stability and allows IPOPT to find feasible poin
 
 ---
 
+## NLP Strategies
+
+Two NLP formulations are available via `IPOPTControl(nlp_strategy=...)`:
+
+| Strategy | Decision variables | Constraints | Description |
+|---|---|---|---|
+| `WeightedMeanNLP()` | 9 | 4 (3 equality + 1 Q10) | Single mean-weighted body; dorsal/ventral merged by view-factor weights |
+| `MultiSidedNLP()` | 11 | 6 (5 equality + 1 Q10) | Explicit dorsal and ventral sides; two skin temperatures, two insulation temperatures |
+
+`WeightedMeanNLP` is the default. `MultiSidedNLP` gives more accurate results under strongly
+asymmetric conditions (high solar loading) at the cost of a slightly larger NLP.
+
+---
+
 ## Constraints
 
-Four constraints are imposed on the NLP:
+### `WeightedMeanNLP`: 4 constraints
 
-### Constraints 1–3: Heat balance equalities (= 0)
+**Constraints 1–3: Heat balance equalities (= 0)**
 
-These are provided by `HeatExchange.heat_balance(T_core, T_skin, T_insulation, Q_gen; ...)`, which
-returns three residuals:
+Provided by `HeatExchange.nlp_residuals(::WeightedMeanNLPPacked, ...)`, which returns three residuals:
 
 1. **Energy balance residual** (W): net heat flow at the insulation surface must be zero.
 2. **Internal conduction residual** (W): heat flow from core to skin through flesh and fat must
@@ -69,19 +81,45 @@ returns three residuals:
 3. **Skin temperature consistency** (K): skin temperature must be consistent with the
    core–skin gradient given flesh conductivity and body geometry.
 
-These three equality constraints make the three temperature state variables outcomes of the
-six effectors, not free choices.
-
-### Constraint 4: Q10 metabolic scaling inequality (≥ 0)
+**Constraint 4: Q10 metabolic scaling inequality (≥ 0)**
 
 ```
-generated_heat_flow ≥ heat_flow_min × Q10^((core_temperature − setpoint) / 10)
+generated_heat_flow ≥ minimum_heat_flow × Q10^((core_temperature − setpoint) / 10)
+```
+
+### `MultiSidedNLP`: 6 constraints
+
+**Constraints 1–2: Dorsal surface physics (= 0)**
+
+1. **Dorsal surface balance** (W): `residual_energy_balance_d − residual_internal_conduction_d = 0`
+   — pure surface heat exchange (solar, longwave, convection, conduction, net internal heat flow);
+   metabolic and respiration terms cancel algebraically.
+2. **Dorsal skin temperature** (K): `residual_skin_temperature_d = 0`
+
+**Constraints 3–4: Ventral surface physics (= 0)**
+
+3. **Ventral surface balance** (W): `residual_energy_balance_v − residual_internal_conduction_v = 0`
+4. **Ventral skin temperature** (K): `residual_skin_temperature_v = 0`
+
+**Constraint 5: Whole-organism energy balance (= 0)**
+
+```
+metabolic_heat_flow − respiration_heat_flow = dmult × net_metabolic_heat_internal_d + vmult × net_metabolic_heat_internal_v
+```
+
+where `dmult = sky_view_factor + vegetation_view_factor` and `vmult = 1 − dmult`. This mirrors
+the validated rule-based multi-sided solver criterion exactly.
+
+**Constraint 6: Q10 metabolic scaling inequality (≥ 0)**
+
+```
+generated_heat_flow ≥ minimum_heat_flow × Q10^((core_temperature − setpoint) / 10)
 ```
 
 This enforces that minimum metabolic rate rises with core temperature during hyperthermia,
 consistent with the Q10 temperature coefficient of biochemical reactions. In cold conditions it
-has no effect (Q_gen rises naturally to close the energy deficit). In hot conditions it ensures
-the solver does not suppress Q_gen below its temperature-corrected minimum.
+has no effect (generated_heat_flow rises naturally to close the energy deficit). In hot conditions
+it ensures the solver does not suppress generated_heat_flow below its temperature-corrected minimum.
 
 The Q10 value is taken from `MetabolismParameters.q10` in `HeatExchange.jl`.
 
@@ -103,7 +141,7 @@ J = w_core × ((core_temperature − setpoint) / Δcore_temperature)²
 
 where `Δ` denotes the range of each variable over its physiological limits.
 
-### Why Q_gen is not the primary target
+### Why generated_heat_flow is not the primary target
 
 `generated_heat_flow` is a state variable. In cold conditions, keeping `core_temperature` near
 setpoint already forces `generated_heat_flow` upward (less metabolic heat → larger energy deficit
@@ -124,12 +162,12 @@ The weights are stored as fields of `ThermoregulationLimits`:
 
 | Field | Default | Effect |
 |---|---|---|
-| `core_temperature_penalty` | 1.0 | Lower → T_core allowed to deviate more before effectors are exhausted |
-| `metabolic_heat_penalty` | 0.1 | Small regularisation to prevent high-panting/high-Q_gen degeneracy in cold |
+| `core_temperature_penalty` | 1.0 | Lower → core temperature allowed to deviate more before effectors are exhausted |
+| `metabolic_heat_penalty` | 0.1 | Small regularisation to prevent high-panting/high-generated_heat_flow degeneracy in cold |
 | `panting_penalty` | 1.0 | Lower → panting activates sooner |
 | `skin_wetness_penalty` | 1.0 | Higher than `panting_penalty` → panting before sweating (birds/rabbits); lower → sweating first (humans) |
 | `gradient_penalty` | 0.0 | Non-zero → penalises deviation from `target_core_skin_gradient` (K); disabled by default |
-| `target_core_skin_gradient` | 2.0 | Target T_core − T_skin (K); only used when `gradient_penalty > 0` |
+| `target_core_skin_gradient` | 2.0 | Target `core_temperature − skin_temperature` (K); only used when `gradient_penalty > 0` |
 
 ---
 
@@ -141,7 +179,7 @@ The weights are stored as fields of `ThermoregulationLimits`:
 | **Cold response** | Piloerect → curl → vasoconstrict → thermogenesis (strict order) | All effectors adjusted together; `metabolic_heat_penalty` regularisation biases toward the rule-based ordering |
 | **Hot response** | Vasodilate → allow hyperthermia → pant → sweat (strict order) | Order emerges from relative penalty weights |
 | **Panting vs sweating** | Set by `mode` (e.g. `CorePantingSweatingFirst`) | Set by `panting_penalty` vs `skin_wetness_penalty` relative magnitudes |
-| **Q10 scaling** | Applied explicitly: `Q_gen_min` rises with Q10 at each step | Enforced via inequality constraint 4 |
+| **Q10 scaling** | Applied explicitly: `generated_heat_flow_min` rises with Q10 at each step | Enforced via inequality constraint 4 |
 | **Core temperature** | Set explicitly by `hyperthermia()` when energy balance cannot close | Free to rise within bounds; penalised by `core_temperature_penalty` |
 | **Speed** | Fast (iterative, closed-form steps) | Comparable in practice; both approaches take similar wall time per temperature point |
 | **Tuning** | Logic rules and step sizes | Five scalar penalty weights |
@@ -187,11 +225,11 @@ rule-based solver and is the natural choice for a sequence that changes smoothly
 environmental conditions:
 
 ```julia
-generated_heat_flow_ipopt    = Q_minimum                          # start at minimum metabolic rate
+generated_heat_flow_ipopt    = minimum_heat_flow                          # start at minimum metabolic rate
 skin_temperature_ipopt       = core_temperature - 3.0u"K"
 insulation_temperature_ipopt = air_temperatures[1]
 
-for (T_air, ...) in zip(air_temperatures, ...)
+for (air_temperature, ...) in zip(air_temperatures, ...)
     # ... build organism and environment ...
     out = thermoregulate(Endotherm(), IPOPTControl(), organism, environment,
                          generated_heat_flow_ipopt, skin_temperature_ipopt, insulation_temperature_ipopt)
@@ -204,7 +242,7 @@ end
 
 For a single solve (e.g., during testing), any physiologically plausible initial point works —
 for example `generated_heat_flow_init = 0.0u"W"` (clamped to `heat_flow_min` inside the solver),
-`skin_temperature_init` near `T_setpoint - 3 K`, and `insulation_temperature_init` near ambient temperature.
+`skin_temperature_init` near `setpoint_temperature - 3 K`, and `insulation_temperature_init` near ambient temperature.
 
 ---
 
@@ -224,36 +262,30 @@ by `solve_metabolic_rate` and keeps the NLP problem dimensionality manageable.
 
 ---
 
-## HeatExchange.jl: `heat_balance` Function
+## HeatExchange.jl NLP Interface
 
-The IPOPT solver does **not** call `solve_metabolic_rate`. Instead it calls a dedicated lower-level
-function `HeatExchange.heat_balance` (added on the `IPOPT-preparation` branch), which evaluates
-the heat balance residuals for an arbitrary set of trial temperatures and effectors without
-performing any iterative solve of its own.
+The IPOPT solver does **not** call `solve_metabolic_rate`. Instead it uses three functions from
+`HeatExchange.jl/src/nlp_interface.jl`:
+
+- **`nlp_pack(strategy, organism, environment, skin_temperature_init, insulation_temperature_init)`** —
+  pre-computes all geometry and environment quantities that are fixed for a given hour, returning a
+  packed parameter struct (`WeightedMeanNLPPacked` or `MultiSidedNLPPacked`).
+
+- **`nlp_residuals(packed, core_temperature, skin_temperature, insulation_temperature, metabolic_heat_flow, ...)`** —
+  evaluates the heat balance residuals for a trial set of decision variables without any iterative
+  solve. Returns a `NamedTuple` with `residuals` (tuple of physics residuals in W/K) plus
+  individual heat flow components.
+
+- **`nlp_assemble_output(packed, organism, environment, ...)`** —
+  reconstructs the full thermoregulation output `NamedTuple` from the solver solution, including
+  respiration, mass flows, and energy flows in the same format as `solve_metabolic_rate`.
 
 This distinction is critical: `solve_metabolic_rate` internally iterates to find consistent
 temperatures given a fixed set of physiological parameters. The IPOPT solver cannot use it as a
-constraint because the temperatures themselves are decision variables — passing a trial `T_core`
-to `solve_metabolic_rate` would trigger a nested solve that ignores the optimizer's current
-guess. `heat_balance` instead accepts all four temperature/heat values as explicit arguments and
-simply returns the residuals, leaving the root-finding entirely to IPOPT.
-
-The function signature is:
-
-```julia
-HeatExchange.heat_balance(
-    core_temperature, skin_temperature, insulation_temperature, generated_heat_flow;
-    body, insulation_pars, insulation, geometry_vars, environment_vars, traits,
-    resp_pars, k_flesh, pant, skin_wetness,
-)
-```
-
-It returns a `NamedTuple` with:
-- `residual_energy_balance` (W) — net heat flow at the body surface (must equal zero at equilibrium)
-- `residual_internal_conduction` (W) — internal core-to-skin conduction imbalance (must equal zero)
-- `residual_skin_temperature` (K) — skin temperature consistency residual (must equal zero)
-- `radiation_heat_flow`, `convection_heat_flow`, `conduction_heat_flow` — individual fluxes
-- `skin_evaporation_heat_flow`, `insulation_evaporation_heat_flow`, `respiration_heat_flow`
+constraint because the temperatures themselves are decision variables — passing a trial
+`core_temperature` to `solve_metabolic_rate` would trigger a nested solve that ignores the
+optimizer's current guess. `nlp_residuals` instead accepts all temperature and effector values
+as explicit arguments and simply returns the residuals, leaving the root-finding entirely to IPOPT.
 
 ---
 
@@ -266,17 +298,17 @@ as input to the other.
 
 ```julia
 # Rule-based pass
-for (T_air, rh, q10) in zip(air_temperatures, ...)
-    out = thermoregulate(organism, environment, 0.0u"W", skin_temperature, T_insulation)
+for (air_temperature, rh, q10) in zip(air_temperatures, ...)
+    out = thermoregulate(organism, environment, 0.0u"W", skin_temperature, insulation_temperature)
     push!(results, ...)
 end
 
 # IPOPT pass (carry-forward initialisation)
-generated_heat_flow_ipopt    = Q_minimum
+generated_heat_flow_ipopt    = minimum_heat_flow
 skin_temperature_ipopt       = core_temperature - 3.0u"K"
 insulation_temperature_ipopt = air_temperatures[1]
 
-for (T_air, rh, q10) in zip(air_temperatures, ...)
+for (air_temperature, rh, q10) in zip(air_temperatures, ...)
     out = thermoregulate(Endotherm(), IPOPTControl(), organism, environment,
                          generated_heat_flow_ipopt, skin_temperature_ipopt, insulation_temperature_ipopt)
     generated_heat_flow_ipopt    = out.energy_flows.generated_heat_flow

--- a/examples/budgerigar.jl
+++ b/examples/budgerigar.jl
@@ -24,7 +24,7 @@ enbal = DataFrame(CSV.File("$testdir/data/budgerigar/enbal.csv"))[:, 2:end]
 masbal = DataFrame(CSV.File("$testdir/data/budgerigar/masbal.csv"))[:, 2:end]
 
 # budgerigar parameters
-shape_pars = example_ellipsoid_shape_pars(; mass = 33.7u"g", aspect_ratio_b = 1.1, aspect_ratio_c = 1.1)
+shape_pars = example_ellipsoid_shape_pars(; mass = 33.7u"g", axis_ratio_b = 1.1, axis_ratio_c = 1.1)
 insulation_pars = example_insulation_pars(;
                     fibre_diameter_dorsal = 30.0u"μm",
                     fibre_diameter_ventral = 30.0u"μm",
@@ -46,14 +46,14 @@ evaporation_pars = example_evaporation_pars(; skin_wetness = 0.005)
 
 # set up geometry
 conduction_pars_internal = example_conduction_pars_internal()
-fat = Fat(conduction_pars_internal.fat_fraction, conduction_pars_internal.fat_density)
+fat = FatLayer(conduction_pars_internal.fat_fraction, conduction_pars_internal.fat_density)
 mean_insulation_depth = insulation_pars.dorsal.depth * (1 - radiation_pars.ventral_fraction) +
     insulation_pars.ventral.depth * radiation_pars.ventral_fraction
 mean_fibre_diameter = insulation_pars.dorsal.diameter * (1 - radiation_pars.ventral_fraction) +
     insulation_pars.ventral.diameter * radiation_pars.ventral_fraction
 mean_fibre_density = insulation_pars.dorsal.density * (1 - radiation_pars.ventral_fraction) +
     insulation_pars.ventral.density * radiation_pars.ventral_fraction
-fur = Fur(mean_insulation_depth, mean_fibre_diameter, mean_fibre_density)
+fur = FibrousLayer(mean_insulation_depth, mean_fibre_diameter, mean_fibre_density)
 geometry = Body(shape_pars, CompositeInsulation(fur, fat))
 
 # environmental conditions
@@ -74,7 +74,7 @@ environment_pars = example_environment_pars()
 skin_temperature = metabolism_pars.core_temperature - 3.0u"K"
 insulation_temperature = environment_vars.air_temperature
 min_metabolic_heat_flow = metabolism_pars.metabolic_heat_flow
-generated_heat_flow = 0.0u"W"
+metabolic_heat_flow = 0.0u"W"
 
 # Thermoregulation limits
 core_temperature_ref = metabolism_pars.core_temperature
@@ -177,7 +177,7 @@ environment = (; environment_pars, environment_vars)
 endotherm_out = thermoregulate(
     organism,
     environment,
-    generated_heat_flow,
+    metabolic_heat_flow,
     skin_temperature,
     insulation_temperature,
 )
@@ -228,13 +228,13 @@ results = NamedTuple[]
     #--- Initial conditions (reset every run!) ---
     skin_temperature_loop = metabolism_pars_loop.core_temperature - 3.0u"K"
     insulation_temperature_loop = environment_vars_loop.air_temperature
-    generated_heat_flow_loop = 0.0u"W"
+    metabolic_heat_flow_loop = 0.0u"W"
 
     # --- Thermoregulation ---
     local endotherm_out = thermoregulate(
         organism_loop,
         environment_loop,
-        generated_heat_flow_loop,
+        metabolic_heat_flow_loop,
         skin_temperature_loop,
         insulation_temperature_loop,
     )
@@ -248,20 +248,20 @@ results = NamedTuple[]
         relative_humidity = relative_humidity,
         q10 = q10,
 
-        generated_heat_flow = ef.generated_heat_flow,
+        metabolic_heat_flow = ef.metabolic_heat_flow,
         core_temperature = tr.core_temperature,
-        skin_temperature_dorsal = tr.skin_temperature_dorsal,
-        skin_temperature_ventral = tr.skin_temperature_ventral,
-        insulation_temperature_dorsal = tr.insulation_temperature_dorsal,
-        insulation_temperature_ventral = tr.insulation_temperature_ventral,
+        skin_temperature_dorsal = tr.dorsal.skin_temperature,
+        skin_temperature_ventral = tr.ventral.skin_temperature,
+        insulation_temperature_dorsal = tr.dorsal.insulation_temperature,
+        insulation_temperature_ventral = tr.ventral.insulation_temperature,
 
-        insulation_depth_dorsal = tr.insulation_depth_dorsal,
-        insulation_depth_ventral = tr.insulation_depth_ventral,
-        insulation_conductivity_dorsal = tr.insulation_conductivity_dorsal,
-        insulation_conductivity_ventral = tr.insulation_conductivity_ventral,
+        insulation_depth_dorsal = tr.dorsal.insulation_depth,
+        insulation_depth_ventral = tr.ventral.insulation_depth,
+        insulation_conductivity_dorsal = tr.dorsal.insulation_conductivity,
+        insulation_conductivity_ventral = tr.ventral.insulation_conductivity,
         insulation_conductivity_effective = tr.insulation_conductivity_effective,
 
-        shape_b = tr.shape_b,
+        axis_ratio_b = tr.axis_ratio_b,
         flesh_conductivity = tr.flesh_conductivity,
 
         pant = tr.pant,
@@ -269,7 +269,7 @@ results = NamedTuple[]
 
         air_flow = mf.air_flow,
         evaporation_mass = mf.m_evap,
-        respiration_mass = mf.respiration_mass,
+        respiration_mass = mf.respiration_mass_flow,
         sweat_mass = mf.m_sweat,
     ))
 end
@@ -282,7 +282,7 @@ default(guidefontsize=8, titlefontsize=10)
 plot_NicheMapR_output = false
 
 p1 = plot(
-    u"°C".(air_temperatures), predicted.generated_heat_flow,
+    u"°C".(air_temperatures), predicted.metabolic_heat_flow,
     lw = 2,
     xlabel = "air temperature",
     title = "metabolic rate",
@@ -511,7 +511,7 @@ println("\nRunning IPOPT across temperatures...")
 
 ipopt_results = NamedTuple[]
 
-generated_heat_flow_ipopt       = min_metabolic_heat_flow
+metabolic_heat_flow_ipopt       = min_metabolic_heat_flow
 skin_temperature_ipopt          = metabolism_pars_init.core_temperature - 3.0u"K"
 insulation_temperature_ipopt    = air_temperatures[1]
 
@@ -543,10 +543,10 @@ insulation_temperature_ipopt    = air_temperatures[1]
 
     out = thermoregulate(
         Endotherm(), IPOPTControl(), organism_loop, environment_loop,
-        generated_heat_flow_ipopt, skin_temperature_ipopt, insulation_temperature_ipopt,
+        metabolic_heat_flow_ipopt, skin_temperature_ipopt, insulation_temperature_ipopt,
     )
 
-    global generated_heat_flow_ipopt    = out.energy_flows.generated_heat_flow
+    global metabolic_heat_flow_ipopt    = out.energy_flows.metabolic_heat_flow
     global skin_temperature_ipopt       = out.thermoregulation.skin_temperature
     global insulation_temperature_ipopt = out.thermoregulation.insulation_temperature
 
@@ -556,21 +556,21 @@ insulation_temperature_ipopt    = air_temperatures[1]
 
     push!(ipopt_results, (
         air_temperature               = air_temperature,
-        generated_heat_flow           = ef.generated_heat_flow,
+        metabolic_heat_flow           = ef.metabolic_heat_flow,
         core_temperature              = tr.core_temperature,
-        skin_temperature_dorsal       = tr.skin_temperature_dorsal,
-        skin_temperature_ventral      = tr.skin_temperature_ventral,
-        insulation_temperature_dorsal           = tr.insulation_temperature_dorsal,
-        insulation_temperature_ventral          = tr.insulation_temperature_ventral,
-        insulation_depth_dorsal       = tr.insulation_depth_dorsal,
-        shape_b           = tr.shape_b,
+        skin_temperature_dorsal       = tr.dorsal.skin_temperature,
+        skin_temperature_ventral      = tr.ventral.skin_temperature,
+        insulation_temperature_dorsal           = tr.dorsal.insulation_temperature,
+        insulation_temperature_ventral          = tr.ventral.insulation_temperature,
+        insulation_depth_dorsal       = tr.dorsal.insulation_depth,
+        axis_ratio_b      = tr.aspect_ratio,
         flesh_conductivity            = tr.flesh_conductivity,
         pant                          = tr.pant,
         skin_wetness                  = tr.skin_wetness,
         balance                       = ef.balance,
         air_flow                      = mf.air_flow,
         evaporation_mass              = mf.m_evap,
-        respiration_mass              = mf.respiration_mass,
+        respiration_mass              = mf.respiration_mass_flow,
         sweat_mass                    = mf.m_sweat,
     ))
 end
@@ -580,12 +580,12 @@ ipopt_predicted = DataFrame(ipopt_results)
 # --- comparison plots (2×2, mirrors original budgerigar layout) ---
 
 pc1 = plot(
-    u"°C".(air_temperatures), predicted.generated_heat_flow,
+    u"°C".(air_temperatures), predicted.metabolic_heat_flow,
     lw = 2, label = "predicted",
     xlabel = "air temperature", title = "metabolic rate",
     ylim = (0.2, 1.2),
 )
-plot!(pc1, u"°C".(air_temperatures), ipopt_predicted.generated_heat_flow,
+plot!(pc1, u"°C".(air_temperatures), ipopt_predicted.metabolic_heat_flow,
     lw = 2, linestyle = :dash, label = "IPOPT")
 scatter!(pc1,
     (Weathers1976Fig1.Tair .+ 273.15)u"K",
@@ -685,13 +685,13 @@ plot!(pc6, u"°C".(air_temperatures), u"W/m/K".(ipopt_predicted.flesh_conductivi
 plot!(pc6, legend = :topleft, legendfontsize = 6)
 
 pc7 = plot(
-    u"°C".(air_temperatures), predicted.shape_b,
+    u"°C".(air_temperatures), predicted.axis_ratio_b,
     lw = 2, label = "predicted",
     xlabel = "air temperature (°C)", ylabel = "aspect ratio (b)",
     title = "body shape",
     xlim = (-5, 50),
 )
-plot!(pc7, u"°C".(air_temperatures), ipopt_predicted.shape_b,
+plot!(pc7, u"°C".(air_temperatures), ipopt_predicted.axis_ratio_b,
     lw = 2, linestyle = :dash, label = "IPOPT")
 plot!(pc7, legend = :bottomright, legendfontsize = 6)
 

--- a/examples/budgerigar.jl
+++ b/examples/budgerigar.jl
@@ -39,8 +39,8 @@ insulation_pars = example_insulation_pars(;
                     insulation_reflectance_ventral=0.351,
                     )
 radiation_pars = example_radiation_pars()
-Q_metabolism = metabolic_rate(McKechnieWolf(), shape_pars.mass)
-metabolism_pars = example_metabolism_pars(; core_temperature = (38.0 + 273.15)u"K", q10 = 2, metabolic_heat_flow = Q_metabolism)
+metabolic_heat_flow = metabolic_rate(McKechnieWolf(), shape_pars.mass)
+metabolism_pars = example_metabolism_pars(; core_temperature = (38.0 + 273.15)u"K", q10 = 2, metabolic_heat_flow)
 respiration_pars = example_respiration_pars(; oxygen_extraction_efficiency=0.25, exhaled_temperature_offset=5.0u"K")
 evaporation_pars = example_evaporation_pars(; skin_wetness = 0.005)
 
@@ -107,7 +107,7 @@ function create_organism(shape_pars, insulation_pars, conduction_pars_internal, 
             tolerance=0.005,
             max_iterations=1000,
         ),
-        Q_minimum_ref=min_metabolic_heat_flow,
+        minimum_heat_flow=min_metabolic_heat_flow,
         insulation=InsulationLimits(;
             dorsal=SteppedParameter(;
                 current=insulation_pars.dorsal.length * 0.7,
@@ -169,7 +169,7 @@ function create_organism(shape_pars, insulation_pars, conduction_pars_internal, 
 end
 
 # Initial run
-metabolism_pars_init = example_metabolism_pars(; core_temperature = (38.0 + 273.15)u"K", q10 = q10s[1], metabolic_heat_flow = Q_metabolism)
+metabolism_pars_init = example_metabolism_pars(; core_temperature = (38.0 + 273.15)u"K", q10 = q10s[1], metabolic_heat_flow)
 organism = create_organism(shape_pars, insulation_pars, conduction_pars_internal, radiation_pars,
                            evaporation_pars, respiration_pars, metabolism_pars_init, geometry)
 environment = (; environment_pars, environment_vars)

--- a/examples/ectotherm.jl
+++ b/examples/ectotherm.jl
@@ -149,22 +149,22 @@ available_environments = AvailableEnvironments(
 
 # ── Organism ──────────────────────────────────────────────────────────────
 # 40 g desert iguana (Dipsosaurus dorsalis) — parameters from Porter et al. (1973)
-#   alpha_max = 0.80 (maximum absorption at Tb < T_active_min, p. 10)
-#   alpha_min = 0.60 (minimum absorption at Tb > T_active_max, p. 10)
-#   T_active_min = 38°C (minimum activity temperature, p. 20)
-#   T_active_max = 43°C (maximum voluntary Tb, p. 20)
-#   T_target     = 38.5°C (preferred temperature from DeWitt 1967, cited p. 19)
+#   alpha_max = 0.80 (maximum absorption at Tb < active_temperature_min, p. 10)
+#   alpha_min = 0.60 (minimum absorption at Tb > active_temperature_max, p. 10)
+#   active_temperature_min = 38°C (minimum activity temperature, p. 20)
+#   active_temperature_max = 43°C (maximum voluntary Tb, p. 20)
+#   target_temperature     = 38.5°C (preferred temperature from DeWitt 1967, cited p. 19)
 #   can_climb = true (paper explicitly models climbing into creosote bushes to 200 cm)
 body            = Body(DesertIguana(40.0u"g", 1000.0u"kg/m^3"), Naked())
 organism_traits = example_ectotherm_organism_traits(
     activity_period         = CombinedActivity(Diurnal(), Crepuscular()), #Diurnal(),
-    T_target                = u"K"(38.5u"°C"),
-    T_active_min            = u"K"(38.0u"°C"),
-    T_active_max            = u"K"(43.0u"°C"),
-    T_bask_min              = u"K"(34.0u"°C"),
-    T_emerge_min            = u"K"(15.0u"°C"),
-    T_critical_min          = u"K"(3.0u"°C"),
-    T_critical_max          = u"K"(44.0u"°C"),
+    target_temperature       = u"K"(38.5u"°C"),
+    active_temperature_min   = u"K"(38.0u"°C"),
+    active_temperature_max   = u"K"(43.0u"°C"),
+    basking_temperature_min  = u"K"(34.0u"°C"),
+    emerge_temperature_min   = u"K"(15.0u"°C"),
+    critical_temperature_min = u"K"(3.0u"°C"),
+    critical_temperature_max = u"K"(44.0u"°C"),
     can_climb               = true,
     can_retreat_underground = true,
     depth_min_underground   = 3,
@@ -251,8 +251,8 @@ month_ht     = [ustrip.(u"m", height[r]) for r in month_ranges]
 month_pos    = [pos_cm[r]               for r in month_ranges]
 month_Ta     = [ustrip.(u"°C", air_temperature[r]) for r in month_ranges]
 
-T_active_min_C = ustrip(u"°C", limits.T_active_min)
-T_active_max_C = ustrip(u"°C", limits.T_active_max)
+active_temperature_min_C = ustrip(u"°C", limits.active_temperature_min)
+active_temperature_max_C = ustrip(u"°C", limits.active_temperature_max)
 
 # ── Fig. 1 – Body temperature for all 12 months (4×3 grid) ───────────────
 # Porter (1973) Tb overlay shown only for March (month 3) and July (month 7)
@@ -262,7 +262,7 @@ panels_Tb = map(1:ndays) do m
         title = months[m] * " (day $(days[m]))",
         ylabel = "°C", ylim = (0, 55), titlefontsize = 9)
     plot!(p, hours, month_Ta[m]; lw = 1, color = :steelblue, linestyle = :dash, label = "")
-    hline!(p, [T_active_min_C, T_active_max_C]; color = :orange, linestyle = :dash, lw = 1, label = "")
+    hline!(p, [active_temperature_min_C, active_temperature_max_C]; color = :orange, linestyle = :dash, lw = 1, label = "")
     p
 end
 

--- a/examples/endotherm.jl
+++ b/examples/endotherm.jl
@@ -17,14 +17,14 @@ respiration_pars = example_respiration_pars()
 
 # set up geometry
 conduction_pars_internal = example_conduction_pars_internal()
-fat = Fat(conduction_pars_internal.fat_fraction, conduction_pars_internal.fat_density)
+fat = FatLayer(conduction_pars_internal.fat_fraction, conduction_pars_internal.fat_density)
 mean_insulation_depth = insulation_pars.dorsal.depth * (1 - radiation_pars.ventral_fraction) +
     insulation_pars.ventral.depth * radiation_pars.ventral_fraction
 mean_fibre_diameter = insulation_pars.dorsal.diameter * (1 - radiation_pars.ventral_fraction) +
     insulation_pars.ventral.diameter * radiation_pars.ventral_fraction
 mean_fibre_density = insulation_pars.dorsal.density * (1 - radiation_pars.ventral_fraction) +
     insulation_pars.ventral.density * radiation_pars.ventral_fraction
-fur = Fur(mean_insulation_depth, mean_fibre_diameter, mean_fibre_density)
+fur = FibrousLayer(mean_insulation_depth, mean_fibre_diameter, mean_fibre_density)
 geometry = Body(shape_pars, CompositeInsulation(fur, fat))
 
 # Create physiology traits (HeatExchangeTraits)
@@ -114,12 +114,12 @@ environment = (; environment_pars, environment_vars)
 # initial conditions
 skin_temperature = metabolism_pars.core_temperature - 3.0u"K"
 insulation_temperature = environment_vars.air_temperature
-generated_heat_flow = 0.0u"W"
+metabolic_heat_flow = 0.0u"W"
 
 endotherm_out = thermoregulate(
     organism,
     environment,
-    generated_heat_flow,
+    metabolic_heat_flow,
     skin_temperature,
     insulation_temperature,
 )

--- a/examples/endotherm.jl
+++ b/examples/endotherm.jl
@@ -50,7 +50,7 @@ thermoregulation_limits = ThermoregulationLimits(;
         tolerance=0.005,
         max_iterations=200,
     ),
-    Q_minimum_ref=metabolism_pars.metabolic_heat_flow,
+    minimum_heat_flow=metabolism_pars.metabolic_heat_flow,
     insulation=InsulationLimits(;
         dorsal=SteppedParameter(;
             current=insulation_pars.dorsal.depth,
@@ -66,7 +66,7 @@ thermoregulation_limits = ThermoregulationLimits(;
         ),
     ),
     aspect_ratio_factor=SteppedParameter(;
-        current=shape_pars.b,
+        current=shape_pars.axis_ratio_b,
         max=5.0,
         step=0.1,
     ),

--- a/src/BiophysicalBehaviour.jl
+++ b/src/BiophysicalBehaviour.jl
@@ -52,6 +52,9 @@ export AbstractControlStrategy,
     RuleBasedSequentialControl,
     IPOPTControl
 
+# NLP strategy types (re-exported from HeatExchange for IPOPTControl.nlp_strategy)
+export NLPStrategy, WeightedMeanNLP, MultiSidedNLP
+
 # Thermoregulation modes
 export AbstractThermoregulationMode,
     CoreFirst,
@@ -101,7 +104,7 @@ export is_active,
     orient_perpendicular,
     orient_parallel,
     press_to_ground,
-    increment_T_target
+    increment_target_temperature
 
 # Example constructors – endotherm
 export example_environment_vars,

--- a/src/BiophysicalBehaviour.jl
+++ b/src/BiophysicalBehaviour.jl
@@ -58,9 +58,6 @@ export AbstractThermoregulationMode,
     CoreAndPantingFirst,
     CorePantingSweatingFirst
 
-# Thermoregulation output type
-export ThermoregulationOutput
-
 # Traits structs
 export BehavioralTraits,
     OrganismTraits
@@ -140,7 +137,6 @@ export example_ectotherm_behavioral_limits,
 
 include("organism.jl")
 include("endotherm/endotherm_traits.jl")
-include("endotherm/thermoregulation/heatexchange.jl")
 include("endotherm/thermoregulation/shared.jl")
 include("endotherm/thermoregulation/rulebased.jl")
 include("endotherm/thermoregulation/ipopt.jl")

--- a/src/ectotherm/ectotherm_traits.jl
+++ b/src/ectotherm/ectotherm_traits.jl
@@ -6,14 +6,14 @@ are used for underground retreats.
 
 - `MinShadeOnly()`: always use minimum-shade soil temperatures (NicheMapR `shdburrow=0`)
 - `AdaptiveBurrowShade()`: use max-shade soil if min-shade soil at the shallowest accessible
-  node is outside `[T_critical_min, T_active_max]`; otherwise use min-shade (NicheMapR `shdburrow=1`)
+  node is outside `[critical_temperature_min, active_temperature_max]`; otherwise use min-shade (NicheMapR `shdburrow=1`)
 - `MaxShadeOnly()`: always use maximum-shade soil temperatures (NicheMapR `shdburrow=2`)
 """
 abstract type BurrowShadeMode end
 """Always use minimum-shade soil temperatures for the underground retreat (NicheMapR `shdburrow=0`)."""
 struct MinShadeOnly <: BurrowShadeMode end
 """Adaptive: use max-shade soil temperatures when min-shade soil at the shallowest accessible
-node is outside `[T_critical_min, T_active_max]` (NicheMapR `shdburrow=1`)."""
+node is outside `[critical_temperature_min, active_temperature_max]` (NicheMapR `shdburrow=1`)."""
 struct AdaptiveBurrowShade <: BurrowShadeMode end
 """Always use maximum-shade soil temperatures for the underground retreat (NicheMapR `shdburrow=2`)."""
 struct MaxShadeOnly <: BurrowShadeMode end
@@ -58,23 +58,23 @@ panting parameters).
   too hot via `pant`.
 
 # Fields – thermal thresholds
-Hierarchy: `T_critical_min` ≤ `T_emerge_min` ≤ `T_bask_min` ≤ `T_active_min` ≤ `T_active_max` ≤ `T_critical_max`
+Hierarchy: `critical_temperature_min` ≤ `emerge_temperature_min` ≤ `basking_temperature_min` ≤ `active_temperature_min` ≤ `active_temperature_max` ≤ `critical_temperature_max`
 
-- `T_target::Tp`: `SteppedParameter` for the operative target body temperature
+- `target_temperature::Tp`: `SteppedParameter` for the operative target body temperature
   (NicheMapR TPREF). `reference`/`current` = starting target temperature;
-  `max` = `T_active_max`; `step` = increment per iteration. When Tb > `T_target.current`
-  but < `T_active_max`, the target temperature steps up (hyperthermia tolerance) before
+  `max` = `active_temperature_max`; `step` = increment per iteration. When Tb > `target_temperature.current`
+  but < `active_temperature_max`, the target temperature steps up (hyperthermia tolerance) before
   cooling behaviours are triggered. Reset each hour to `reference`.
-- `T_active_min::T`: Lower activity temperature, TMINPR (T_F_min). Below this the animal
+- `active_temperature_min::T`: Lower activity temperature, TMINPR (T_F_min). Below this the animal
   is basking rather than active.
-- `T_active_max::T`: Upper activity temperature, TMAXPR (T_F_max). When `T_target`
+- `active_temperature_max::T`: Upper activity temperature, TMAXPR (T_F_max). When `target_temperature`
   has stepped up to this value and Tb is still above it, cooling behaviours begin.
-- `T_bask_min::T`: Minimum basking temperature, TBASK (T_B_min). Thermoregulation loop warms
-  the animal to at least `T_bask_min`; the animal is basking (not active) while
-  `T_bask_min ≤ Tb < T_active_min`.
-- `T_critical_min::T`: Critical thermal minimum, CTMIN (lethal lower limit).
-- `T_critical_max::T`: Critical thermal maximum, CTMAX (lethal upper limit).
-- `T_emerge_min::T`: Minimum soil temperature at the previous-hour underground depth to
+- `basking_temperature_min::T`: Minimum basking temperature, TBASK (T_B_min). Thermoregulation loop warms
+  the animal to at least `basking_temperature_min`; the animal is basking (not active) while
+  `basking_temperature_min ≤ Tb < active_temperature_min`.
+- `critical_temperature_min::T`: Critical thermal minimum, CTMIN (lethal lower limit).
+- `critical_temperature_max::T`: Critical thermal maximum, CTMAX (lethal upper limit).
+- `emerge_temperature_min::T`: Minimum soil temperature at the previous-hour underground depth to
   allow emergence, TEMERGE (T_RB_min).
 
 # Fields – capability flags
@@ -109,13 +109,13 @@ Hierarchy: `T_critical_min` ≤ `T_emerge_min` ≤ `T_bask_min` ≤ `T_active_mi
 - `burrow_shade_mode`: A `BurrowShadeMode` value controlling which soil temperatures are used
   for underground retreats. `MinShadeOnly()` = min-shade always; `MaxShadeOnly()` = max-shade
   always; `AdaptiveBurrowShade()` = max-shade when min-shade soil at the shallowest accessible
-  node is outside `[T_critical_min, T_active_max]` (NicheMapR `shdburrow` 0/1/2).
+  node is outside `[critical_temperature_min, active_temperature_max]` (NicheMapR `shdburrow` 0/1/2).
 - `emerge_signal`: Minimum soil-temperature change rate (units `K/hr`) required before the
   animal emerges from a retreat deeper than node 2, when `soil_temperature >= T_emerge_min` and
   no activity has occurred yet today (NicheMapR `warmsig`, default `0.0u"K/hr"` = disabled).
   `> 0`: must detect soil warming of at least this rate (diurnal basker waits for morning warm-up).
   `< 0`: must detect soil cooling of at least this rate (nocturnal animal waits for evening cool-down).
-  `= 0`: emerge whenever `soil_temperature >= T_emerge_min` regardless of trend.
+  `= 0`: emerge whenever `soil_temperature >= emerge_temperature_min` regardless of trend.
 """
 Base.@kwdef struct EctothermBehavioralLimits{
     C<:AbstractControlStrategy,Sh,D,H,T,Tp,Ab,Pa,Ws,Bs<:BurrowShadeMode
@@ -127,13 +127,13 @@ Base.@kwdef struct EctothermBehavioralLimits{
     height::H
     absorptivity::Ab    = SteppedParameter(; current=0.9, reference=0.9, max=0.9, step=0.0)
     pant_rate::Pa       = SteppedParameter(; current=1.0, reference=1.0, max=1.0, step=0.1)
-    T_target::Tp            # SteppedParameter: rises from reference toward T_active_max each iteration
-    T_active_min::T
-    T_active_max::T
-    T_bask_min::T
-    T_critical_min::T
-    T_critical_max::T
-    T_emerge_min::T
+    target_temperature::Tp          # SteppedParameter: rises from reference toward active_temperature_max each iteration
+    active_temperature_min::T
+    active_temperature_max::T
+    basking_temperature_min::T
+    critical_temperature_min::T
+    critical_temperature_max::T
+    emerge_temperature_min::T
     # Capability flags
     can_retreat_underground::Bool   = true
     can_climb::Bool                 = false

--- a/src/ectotherm/ectothermy.jl
+++ b/src/ectotherm/ectothermy.jl
@@ -44,14 +44,14 @@ Find the steady-state body temperature for an ectotherm using Brent's method
 
 Returns the air temperature as a fallback if root-finding fails.
 """
-function solve_body_temperature(organism, env_vars, env_pars, T_bask_min=nothing, T_active_max=nothing)
+function solve_body_temperature(organism, env_vars, env_pars, basking_temperature_min=nothing, active_temperature_max=nothing)
     e = (environment_pars=env_pars, environment_vars=env_vars)
     # Fixed bracket covering physiologically plausible ectotherm body temps (0–70°C).
     lo = 273.15
     hi = 343.15
     # Eyes open only when basking or active (NicheMapR SEVAP.f line 119:
     # IF((TC.GE.TBASK).AND.(TC.LE.TMAXPR))). Pre-build closed-eye organism.
-    org_closed = if !isnothing(T_bask_min)
+    org_closed = if !isnothing(basking_temperature_min)
         @set organism.traits.heat_exchange.evaporation_pars.eye_fraction = 0.0
     else
         organism
@@ -59,7 +59,7 @@ function solve_body_temperature(organism, env_vars, env_pars, T_bask_min=nothing
     try
         core_temperature = zbrent(
             T -> begin
-                org = (!isnothing(T_bask_min) && (T * u"K" < T_bask_min || T * u"K" > T_active_max)) ?
+                org = (!isnothing(basking_temperature_min) && (T * u"K" < basking_temperature_min || T * u"K" > active_temperature_max)) ?
                     org_closed : organism
                 ustrip(u"W", heat_balance(T * u"K", org, e).heat_balance)
             end,
@@ -139,19 +139,19 @@ Core ectotherm behavioural thermoregulation loop (ECTOTHERM.f / ectotherm.R logi
 3. **Inactive period**: if the animal can retreat underground, call `select_depth` to find
    the optimal soil node; otherwise stay above ground.
 4. **Emergence check**: if the animal was underground at the previous step and the soil
-   at that depth is still below `T_emerge_min`, stay underground.
+   at that depth is still below `emerge_temperature_min`, stay underground.
 5. **Active period thermoregulation loop** — organism traits modified in-place via `@set`:
 
-   *Too hot* (core_temperature > T_target.current):
+   *Too hot* (core_temperature > target_temperature.current):
    revert perpendicular→intermediate (same iteration as shade seeking, mirrors
    NicheMapR THERMO.f phase 2 no-RETURN) → `lighten` → `seek_shade` → `climb` →
-   `pant` → `increment_T_target` → `retreat_underground`
+   `pant` → `increment_target_temperature` → `retreat_underground`
 
-   *Too cold* (core_temperature < T_bask_min):
+   *Too cold* (core_temperature < basking_temperature_min):
    `darken` → `orient_perpendicular` → `press_to_ground` → `avoid_shade` →
-   `retreat_underground` (if core_temperature < T_critical_min)
+   `retreat_underground` (if core_temperature < critical_temperature_min)
 
-   *Basking* (T_bask_min ≤ core_temperature < T_active_min): `orient_perpendicular`
+   *Basking* (basking_temperature_min ≤ core_temperature < active_temperature_min): `orient_perpendicular`
 
    Each behaviour modifies both `limits` (state flags / stepped parameters) and a
    local `organism_current` (organism traits). The loop exits when core_temperature
@@ -216,7 +216,7 @@ function thermoregulate(
     end
 
     # -------------------------------------------------------------------------
-    # 3b. Active but was underground last step → check T_emerge_min condition
+    # 3b. Active but was underground last step → check emerge_temperature_min condition
     # -------------------------------------------------------------------------
     if previous_depth > limits.depth.reference
         # Underground temperature is binary (shaded or unshaded location),
@@ -246,7 +246,7 @@ function thermoregulate(
                               (limits.emerge_signal < zero(limits.emerge_signal) && soil_delta > limits.emerge_signal)
         end
 
-        if soil_temperature_at_depth < limits.T_emerge_min || stay_for_signal
+        if soil_temperature_at_depth < limits.emerge_temperature_min || stay_for_signal
             # Stay underground — re-run select_depth to find the best available node for
             # this hour (mirrors NicheMapR calling SELDEP.f each inactive hour). This
             # allows the animal to move deeper when its current node cools below CT_min.
@@ -260,7 +260,7 @@ function thermoregulate(
     # 4. Active above ground: behavioural thermoregulation loop
     # -------------------------------------------------------------------------
     env                      = interpolate_environment(available_environments, step, limits, environmental_params)
-    core_temperature         = solve_body_temperature(organism_current, env, environmental_params, limits.T_bask_min, limits.T_active_max)
+    core_temperature         = solve_body_temperature(organism_current, env, environmental_params, limits.basking_temperature_min, limits.active_temperature_max)
     underground_shade_factor = 0.0  # updated if the animal retreats underground during the loop
 
     iteration = 0
@@ -268,25 +268,25 @@ function thermoregulate(
         iteration += 1
 
         # NicheMapR THERMO.f phase 2 (first sub-case): revert perpendicular → intermediate
-        # when core_temperature has risen into the accepted active range [T_active_min, T_target].
+        # when core_temperature has risen into the accepted active range [active_temperature_min, target_temperature].
         # In NicheMapR THERMO.f the revert fires BEFORE the acceptance check, so the
-        # animal always relaxes its posture once it has warmed to T_active_min.
+        # animal always relaxes its posture once it has warmed to active_temperature_min.
         # After reverting, recalculate core_temperature (now lower with intermediate area) and break;
         # no further actions are attempted (matches THERMO.f phase 4 no-action → return).
         if limits.can_solar_orient && limits.sun_orientation == 90.0 &&
-               core_temperature >= limits.T_active_min && core_temperature <= limits.T_target.current
+               core_temperature >= limits.active_temperature_min && core_temperature <= limits.target_temperature.current
             limits, organism_current = orient_intermediate(organism_current, limits)
             env              = interpolate_environment(available_environments, step, limits, environmental_params)
-            core_temperature = solve_body_temperature(organism_current, env, environmental_params, limits.T_bask_min, limits.T_active_max)
+            core_temperature = solve_body_temperature(organism_current, env, environmental_params, limits.basking_temperature_min, limits.active_temperature_max)
             break
         end
 
-        # NicheMapR ECTOTHERM.f line 3333: accept if core_temperature ∈ [T_active_min, T_target].
-        if core_temperature >= limits.T_active_min && core_temperature <= limits.T_target.current
+        # NicheMapR ECTOTHERM.f line 3333: accept if core_temperature ∈ [active_temperature_min, target_temperature].
+        if core_temperature >= limits.active_temperature_min && core_temperature <= limits.target_temperature.current
             break
         end
 
-        if core_temperature > limits.T_target.current
+        if core_temperature > limits.target_temperature.current
             # -- Too hot --
             # NicheMapR THERMO.f phase 2 (second sub-case, no RETURN): revert
             # perpendicular → intermediate in the SAME iteration as shade seeking.
@@ -302,8 +302,8 @@ function thermoregulate(
             elseif limits.can_seek_shade && limits.shade.current < limits.shade.max
                 limits = seek_shade(limits)
 
-            elseif limits.T_target.current < limits.T_target.max
-                limits = increment_T_target(limits)
+            elseif limits.target_temperature.current < limits.target_temperature.max
+                limits = increment_target_temperature(limits)
 
             elseif limits.can_climb && limits.height.current < limits.height.max
                 limits = climb(limits)
@@ -320,7 +320,7 @@ function thermoregulate(
                 break
             end
 
-        elseif core_temperature < limits.T_bask_min
+        elseif core_temperature < limits.basking_temperature_min
             # -- Too cold: darken → perpendicular → press to ground → avoid shade → retreat_underground --
             if limits.can_change_absorptivity &&
                limits.absorptivity.current < limits.absorptivity.max
@@ -339,7 +339,7 @@ function thermoregulate(
                 # Night: seek shade to reduce longwave loss to cold sky
                 limits = seek_shade(limits)
 
-            elseif limits.can_climb && core_temperature < limits.T_critical_min && limits.height.current < limits.height.max
+            elseif limits.can_climb && core_temperature < limits.critical_temperature_min && limits.height.current < limits.height.max
                 limits = climb(limits)
 
             elseif limits.can_retreat_underground
@@ -354,8 +354,8 @@ function thermoregulate(
             end
 
         elseif limits.can_solar_orient && limits.sun_orientation < 90.0 &&
-               core_temperature < limits.T_active_min
-            # -- Basking range [T_bask_min, T_active_min): orient NormalToSun to maximise solar gain --
+               core_temperature < limits.active_temperature_min
+            # -- Basking range [basking_temperature_min, active_temperature_min): orient NormalToSun to maximise solar gain --
             limits, organism_current = orient_perpendicular(organism_current, limits)
 
         else
@@ -363,7 +363,7 @@ function thermoregulate(
         end
 
         env              = interpolate_environment(available_environments, step, limits, environmental_params)
-        core_temperature = solve_body_temperature(organism_current, env, environmental_params, limits.T_bask_min, limits.T_active_max)
+        core_temperature = solve_body_temperature(organism_current, env, environmental_params, limits.basking_temperature_min, limits.active_temperature_max)
     end
 
     return _build_ectotherm_output(organism_current, env, environmental_params, limits, active, available_environments, underground_shade_factor)
@@ -382,8 +382,8 @@ function _build_ectotherm_output(organism, env_vars, env_pars, limits, in_active
     # surrounding temperatures equal soil_temperature and heat loss pathways are near zero.
     core_temperature = (is_underground && !limits.solve_underground) ?
                        env_vars.air_temperature :
-                       solve_body_temperature(organism, env_vars, env_pars, limits.T_bask_min, limits.T_active_max)
-    org_out  = (limits.T_bask_min <= core_temperature <= limits.T_active_max) ? organism :
+                       solve_body_temperature(organism, env_vars, env_pars, limits.basking_temperature_min, limits.active_temperature_max)
+    org_out  = (limits.basking_temperature_min <= core_temperature <= limits.active_temperature_max) ? organism :
                @set organism.traits.heat_exchange.evaporation_pars.eye_fraction = 0.0
     ecto_out = heat_balance(core_temperature, org_out, e)
     height = if is_underground
@@ -398,9 +398,9 @@ function _build_ectotherm_output(organism, env_vars, env_pars, limits, in_active
     #   ACT=2 (Active):   T_F_min <= Tc <= T_F_max
     state = if !in_active_period || is_underground
         Resting()
-    elseif limits.T_active_min <= core_temperature <= limits.T_active_max
+    elseif limits.active_temperature_min <= core_temperature <= limits.active_temperature_max
         Active()
-    elseif limits.T_bask_min <= core_temperature < limits.T_active_min
+    elseif limits.basking_temperature_min <= core_temperature < limits.active_temperature_min
         Basking()
     else
         Resting()

--- a/src/ectotherm/example_variables_and_parameters.jl
+++ b/src/ectotherm/example_variables_and_parameters.jl
@@ -47,14 +47,14 @@ NicheMapR R `ectotherm()` function defaults (ectotherm.R).
 | `absorptivity_step`          | 0.0       | (derived: alpha_max-alpha_min)|
 | `pant_max`                   | 1.0       | (panting multiplier max)      |
 | `pant_step`                  | 0.1       | (panting step)                |
-| `T_pref`                          | 30.0 °C   | T_pref (TPREF, initial preferred temp; T_target rises to T_F_max)|
-| `T_target_step`                   | 0.5 K     | TBIG (TPREF increment, 0.5 in NicheMapR THERMOREG)|
-| `T_active_min`                    | 24.0 °C   | T_F_min                       |
-| `T_active_max`                    | 34.0 °C   | T_F_max                       |
-| `T_bask_min`                      | 17.5 °C   | T_B_min                       |
-| `T_critical_min`                  | 6.0 °C    | CT_min                        |
-| `T_critical_max`                  | 40.0 °C   | CT_max                        |
-| `T_emerge_min`                    | 15.0 °C   | T_RB_min                      |
+| `target_temperature`              | 30.0 °C   | T_pref (TPREF, initial preferred temp; rises to active_temperature_max)|
+| `target_temperature_step`         | 0.5 K     | TBIG (TPREF increment, 0.5 in NicheMapR THERMOREG)|
+| `active_temperature_min`          | 24.0 °C   | T_F_min                       |
+| `active_temperature_max`          | 34.0 °C   | T_F_max                       |
+| `basking_temperature_min`         | 17.5 °C   | T_B_min                       |
+| `critical_temperature_min`        | 6.0 °C    | CT_min                        |
+| `critical_temperature_max`        | 40.0 °C   | CT_max                        |
+| `emerge_temperature_min`          | 15.0 °C   | T_RB_min                      |
 | `can_retreat_underground`         | `true`    | burrow                        |
 | `can_climb`                       | `false`   | climb                         |
 | `can_seek_shade`                  | `true`    | shade_seek                    |
@@ -83,14 +83,14 @@ function example_ectotherm_behavioral_limits(;
     # Height (atmospheric profile node indices)
     height_max            = typemax(Int), # default = use all available height nodes
     # Thermal thresholds
-    T_target      = u"K"(30.0u"°C"),   # TPREF: starting preferred temp (T_target rises to T_active_max)
-    T_target_step = 0.5u"K",           # TBIG: step size for TPREF increment (0.5 in NicheMapR THERMOREG)
-    T_active_min  = u"K"(24.0u"°C"),
-    T_active_max  = u"K"(34.0u"°C"),
-    T_bask_min       = u"K"(17.5u"°C"),
-    T_critical_min   = u"K"(6.0u"°C"),
-    T_critical_max   = u"K"(40.0u"°C"),
-    T_emerge_min     = u"K"(15.0u"°C"),
+    target_temperature      = u"K"(30.0u"°C"),   # TPREF: starting preferred temp (rises to active_temperature_max)
+    target_temperature_step = 0.5u"K",           # TBIG: step size for TPREF increment (0.5 in NicheMapR THERMOREG)
+    active_temperature_min  = u"K"(24.0u"°C"),
+    active_temperature_max  = u"K"(34.0u"°C"),
+    basking_temperature_min    = u"K"(17.5u"°C"),
+    critical_temperature_min   = u"K"(6.0u"°C"),
+    critical_temperature_max   = u"K"(40.0u"°C"),
+    emerge_temperature_min     = u"K"(15.0u"°C"),
     # Capability flags
     can_retreat_underground      = true,
     can_climb                    = false,
@@ -142,11 +142,11 @@ function example_ectotherm_behavioral_limits(;
         max       = pant_max,
         step      = pant_step,
     )
-    T_target = SteppedParameter(;
-        current   = T_target,
-        reference = T_target,
-        max       = T_active_max,
-        step      = T_target_step,
+    target_temperature = SteppedParameter(;
+        current   = target_temperature,
+        reference = target_temperature,
+        max       = active_temperature_max,
+        step      = target_temperature_step,
     )
     EctothermBehavioralLimits(;
         control,
@@ -156,13 +156,13 @@ function example_ectotherm_behavioral_limits(;
         height,
         absorptivity,
         pant_rate,
-        T_target,
-        T_active_min,
-        T_active_max,
-        T_bask_min,
-        T_critical_min,
-        T_critical_max,
-        T_emerge_min,
+        target_temperature,
+        active_temperature_min,
+        active_temperature_max,
+        basking_temperature_min,
+        critical_temperature_min,
+        critical_temperature_max,
+        emerge_temperature_min,
         can_retreat_underground,
         can_climb,
         can_seek_shade,

--- a/src/ectotherm/thermoregulation.jl
+++ b/src/ectotherm/thermoregulation.jl
@@ -67,8 +67,8 @@ function _underground_blend_factor(::AdaptiveBurrowShade, limits, min_shade, max
     n_nodes          = size(min_shade.soil_temperature, 2)
     min_node         = clamp(limits.depth_min_underground, 1, n_nodes)
     soil_temperature = min_shade.soil_temperature[step, min_node]
-    too_hot          = soil_temperature > limits.T_active_max
-    too_cold         = soil_temperature < limits.T_critical_min
+    too_hot          = soil_temperature > limits.active_temperature_max
+    too_cold         = soil_temperature < limits.critical_temperature_min
     return (too_hot || too_cold) ? 1.0 : 0.0
 end
 
@@ -142,28 +142,28 @@ function reset_position(limits::EctothermBehavioralLimits)
     limits = @set limits.height.current        = limits.height.reference
     limits = @set limits.absorptivity.current  = limits.absorptivity.max
     limits = @set limits.pant_rate.current     = limits.pant_rate.reference
-    limits = @set limits.T_target.current  = limits.T_target.reference
+    limits = @set limits.target_temperature.current  = limits.target_temperature.reference
     limits = @set limits.sun_orientation   = 45.0
     limits = @set limits.pressed_to_ground = false
     return limits
 end
 
 """
-    increment_T_target(limits::EctothermBehavioralLimits) → limits
+    increment_target_temperature(limits::EctothermBehavioralLimits) → limits
 
-Increment the target body temperature by one step toward `T_active_max`.
+Increment the target body temperature by one step toward `active_temperature_max`.
 
 Matches NicheMapR's TPREF incrementing (ECTOTHERM.f ENB>0 branch): the organism
 tolerates a progressively warmer body temperature before triggering cooling
-behaviours. Once `T_target.current` reaches `T_active_max`, shade-seeking and
+behaviours. Once `target_temperature.current` reaches `active_temperature_max`, shade-seeking and
 other cooling responses begin.
 
 Returns updated `EctothermBehavioralLimits`.
 """
-function increment_T_target(limits::EctothermBehavioralLimits)
-    new_T = min(limits.T_target.current + limits.T_target.step,
-                limits.T_target.max)
-    @set limits.T_target.current = new_T
+function increment_target_temperature(limits::EctothermBehavioralLimits)
+    new_T = min(limits.target_temperature.current + limits.target_temperature.step,
+                limits.target_temperature.max)
+    @set limits.target_temperature.current = new_T
 end
 
 # =============================================================================
@@ -253,7 +253,7 @@ Revert solar orientation to the neutral/foraging posture (`sun_orientation = 45.
 
 Sets `solar_orientation = Intermediate()` and `A_silhouette` to the average of
 normal and parallel areas. Called when body temperature re-enters the active range
-after basking (perpendicular → intermediate) or when Tb drops back to T_target
+after basking (perpendicular → intermediate) or when Tb drops back to target_temperature
 after parallel cooling (parallel → intermediate).
 
 Mirrors NicheMapR THERMO.f lines 119-128: revert when TC ≥ TMINPR (from perpendicular)
@@ -318,8 +318,8 @@ end
 Find the shallowest accessible soil node with a tolerable temperature (SELDEP.f).
 
 Iterates from `limits.depth_min_underground` to `limits.depth.max`, selecting the first
-node where the blended soil temperature lies between `T_critical_min` and a
-mid-point threshold between `T_active_max` and `T_critical_max`. Falls back to
+node where the blended soil temperature lies between `critical_temperature_min` and a
+mid-point threshold between `active_temperature_max` and `critical_temperature_max`. Falls back to
 the deepest node if no node is within tolerance.
 
 # Arguments
@@ -330,8 +330,8 @@ the deepest node if no node is within tolerance.
 - `underground_shade_factor`: Blend factor (0=min-shade, 1=max-shade) for soil temperatures
 """
 function select_depth(limits::EctothermBehavioralLimits, min_shade, max_shade, step, underground_shade_factor)
-    depth_selection_threshold = limits.T_critical_max -
-        (limits.T_critical_max - limits.T_active_max) / 2
+    depth_selection_threshold = limits.critical_temperature_max -
+        (limits.critical_temperature_max - limits.active_temperature_max) / 2
 
     n_nodes   = size(min_shade.soil_temperature, 2)
     depth_min = clamp(limits.depth_min_underground, 1, n_nodes)
@@ -343,7 +343,7 @@ function select_depth(limits::EctothermBehavioralLimits, min_shade, max_shade, s
             max_shade.soil_temperature[step, node],
             underground_shade_factor,
         )
-        if limits.T_critical_min < soil_temperature < depth_selection_threshold
+        if limits.critical_temperature_min < soil_temperature < depth_selection_threshold
             return @set limits.depth.current = node
         end
     end

--- a/src/endotherm/endotherm_traits.jl
+++ b/src/endotherm/endotherm_traits.jl
@@ -58,7 +58,7 @@ tissue conductivity, core temperature, panting, and skin wetness.
 
 # Fields
 - `control::C`: Control strategy (RuleBasedSequentialControl, IPOPTControl, etc.)
-- `Q_minimum_ref::Q`: Reference minimum metabolic rate
+- `minimum_heat_flow::Q`: Reference minimum metabolic rate
 - `insulation::InsulationLimits`: Piloerection limits (dorsal/ventral)
 - `aspect_ratio_factor::SteppedParameter`: Body shape adjustment limits (uncurling)
 - `flesh_conductivity::SteppedParameter`: Tissue conductivity limits (vasodilation)
@@ -85,7 +85,7 @@ tissue conductivity, core temperature, panting, and skin wetness.
 """
 Base.@kwdef struct ThermoregulationLimits{C<:AbstractControlStrategy,Q,I,Sh,K,Tc,P,Sw} <: AbstractBehaviourParameters
     control::C = RuleBasedSequentialControl()
-    Q_minimum_ref::Q
+    minimum_heat_flow::Q
     insulation::I
     aspect_ratio_factor::Sh
     flesh_conductivity::K

--- a/src/endotherm/endotherm_traits.jl
+++ b/src/endotherm/endotherm_traits.jl
@@ -67,8 +67,8 @@ tissue conductivity, core temperature, panting, and skin wetness.
 - `skin_wetness::SteppedParameter`: Sweating/cutaneous evaporation limits
 - `core_temperature_penalty::Float64`: IPOPT objective penalty for core temperature deviation from setpoint. Default 1.0.
 - `metabolic_heat_penalty::Float64`: Regularisation weight on metabolic heat generation. A small value
-  (default 0.1) prevents high-panting/high-generated_heat_flow degeneracy in cold conditions. In hot
-  conditions the Q10 inequality constraint overrides this and forces generated_heat_flow up with
+  (default 0.1) prevents high-panting/high-metabolic_heat_flow degeneracy in cold conditions. In hot
+  conditions the Q10 inequality constraint overrides this and forces metabolic_heat_flow up with
   core_temperature, so this value does not impede thermogenesis.
 - `panting_penalty::Float64`: IPOPT objective penalty for panting (normalised to [0,1] range).
   Relative to `skin_wetness_penalty` this controls which activates first. Default 1.0.

--- a/src/endotherm/example_variables_and_parameters.jl
+++ b/src/endotherm/example_variables_and_parameters.jl
@@ -224,7 +224,7 @@ function example_thermoregulation_limits(;
     tolerance=0.005,
     max_iterations=1000,
     # Metabolic reference
-    Q_minimum_ref=77.61842u"W",
+    minimum_heat_flow=77.61842u"W",
     # Insulation (piloerection)
     insulation_depth_dorsal=2e-03u"m",
     insulation_depth_ventral=2e-03u"m",
@@ -315,7 +315,7 @@ function example_thermoregulation_limits(;
 
     ThermoregulationLimits(;
         control,
-        Q_minimum_ref,
+        minimum_heat_flow,
         insulation,
         aspect_ratio_factor=aspect_ratio_param,
         flesh_conductivity=flesh_conductivity_param,

--- a/src/endotherm/example_variables_and_parameters.jl
+++ b/src/endotherm/example_variables_and_parameters.jl
@@ -51,10 +51,10 @@ end
 function example_ellipsoid_shape_pars(;
     mass=65.0u"kg",
     ρ_flesh=1000.0u"kg/m^3",
-    aspect_ratio_b=1.1,
-    aspect_ratio_c=1.1,
+    axis_ratio_b=1.1,
+    axis_ratio_c=1.1,
 )
-    Ellipsoid(mass, ρ_flesh, aspect_ratio_b, aspect_ratio_c)
+    Ellipsoid(mass, ρ_flesh, axis_ratio_b, axis_ratio_c)
 end
 
 # Alias for convenience

--- a/src/endotherm/thermoregulation/behavioural.jl
+++ b/src/endotherm/thermoregulation/behavioural.jl
@@ -26,10 +26,10 @@ positional options (shade, climbing, retreating underground, posture, absorptivi
 
 Operative temperature `Te` (= `solve_body_temperature`: the equilibrium body
 temperature of a passive body in the current environment) is compared to
-`behavioral_limits.T_active_min/max`:
+`behavioral_limits.active_temperature_min/max`:
 
-- `Te > T_active_max` → environment too hot in the open → seek cool microhabitat
-- `Te < T_active_min` → environment too cold → seek warm microhabitat
+- `Te > active_temperature_max` → environment too hot in the open → seek cool microhabitat
+- `Te < active_temperature_min` → environment too cold → seek warm microhabitat
 
 ## Priority sequences
 
@@ -38,7 +38,7 @@ temperature of a passive body in the current environment) is compared to
 
 *Too cold*:
 `darken` → `orient_perpendicular` → `press_to_ground` → `avoid_shade` →
-`retreat_underground` (only if `Te < T_critical_min`)
+`retreat_underground` (only if `Te < critical_temperature_min`)
 
 ## After the behavioural loop
 
@@ -117,7 +117,7 @@ function thermoregulate(
     end
 
     # -------------------------------------------------------------------------
-    # 3b. Active but was underground last step → check T_emerge_min condition
+    # 3b. Active but was underground last step → check emerge_temperature_min condition
     # -------------------------------------------------------------------------
     if prev_step_depth > behavioral_limits.depth.reference
         underground_shade_factor = underground_shade_factor_for(behavioral_limits.shade.reference)
@@ -126,7 +126,7 @@ function thermoregulate(
             max_shade.soil_temperature[step, prev_step_depth],
             underground_shade_factor,
         )
-        if soil_temperature_prev < behavioral_limits.T_emerge_min
+        if soil_temperature_prev < behavioral_limits.emerge_temperature_min
             behavioral_limits = @set behavioral_limits.depth.current = prev_step_depth
             env = interpolate_environment(available_environments, step, behavioral_limits, environmental_params)
             return _build_endotherm_behavioral_output(
@@ -144,7 +144,7 @@ function thermoregulate(
     while iteration < max_iterations
         iteration += 1
 
-        if Te > behavioral_limits.T_active_max * (1 - tolerance)
+        if Te > behavioral_limits.active_temperature_max * (1 - tolerance)
             # Too hot: seek cool microhabitat before panting (water-loss avoidance)
             # lighten → parallel → shade → climb → retreat_underground
             if behavioral_limits.can_change_absorptivity &&
@@ -172,7 +172,7 @@ function thermoregulate(
                 break
             end
 
-        elseif Te < behavioral_limits.T_active_min * (1 + tolerance)
+        elseif Te < behavioral_limits.active_temperature_min * (1 + tolerance)
             # Too cold: seek warm microhabitat
             # darken → perpendicular → press to ground → avoid shade → retreat_underground
             if behavioral_limits.can_change_absorptivity &&
@@ -188,7 +188,7 @@ function thermoregulate(
             elseif behavioral_limits.shade.current > behavioral_limits.shade.reference
                 behavioral_limits = avoid_shade(behavioral_limits)
 
-            elseif behavioral_limits.can_retreat_underground && Te < behavioral_limits.T_critical_min
+            elseif behavioral_limits.can_retreat_underground && Te < behavioral_limits.critical_temperature_min
                 underground_shade_factor = underground_shade_factor_for(behavioral_limits.shade.current)
                 behavioral_limits = select_depth(behavioral_limits, min_shade, max_shade, step,
                                                  underground_shade_factor)

--- a/src/endotherm/thermoregulation/behavioural.jl
+++ b/src/endotherm/thermoregulation/behavioural.jl
@@ -219,7 +219,7 @@ function _build_endotherm_behavioral_output(organism, env_vars, env_pars, behavi
 
     init = initial_physiological_state(organism, env_vars)
     endotherm_out = thermoregulate(organism, e,
-                                   init.generated_heat_flow,
+                                   init.metabolic_heat_flow,
                                    init.skin_temperature,
                                    init.insulation_temperature)
 

--- a/src/endotherm/thermoregulation/ipopt.jl
+++ b/src/endotherm/thermoregulation/ipopt.jl
@@ -5,27 +5,42 @@
 # the Q10 metabolic-scaling inequality constraint.
 # All physics (packing, per-iteration residuals, output assembly) is delegated
 # to HeatExchange.nlp_pack / nlp_residuals / nlp_assemble_output.
+#
+# Two NLP formulations are supported via IPOPTControl.nlp_strategy:
+#   WeightedMeanNLP  — 9 variables, 4 constraints (3 equality + 1 Q10)
+#   MultiSidedNLP    — 11 variables, 6 constraints (5 equality + 1 Q10)
 # =============================================================================
 
 # =============================================================================
 # Hard boundary between unitless optimizer world and Unitful scientific world.
 #
-#   `_objective_value` lives in optimizer world: pure Float64 arithmetic over
+#   `_objective_value_*` lives in optimizer world: pure Float64 arithmetic over
 #       stripped reference values and dimensionless penalty weights.
 #       Never sees a Unitful quantity.
 #
-#   `_heat_balance_residuals!` is the *only* function that crosses the
+#   `_heat_balance_residuals_*!` is the *only* function that crosses the
 #       boundary: Float64 effectors in, Float64 residuals out, Unitful science
 #       in between. Units are attached at the top, stripped at the bottom.
 # =============================================================================
 
-# Pure Float64 objective. `opt` carries only stripped scalars and dimensionless
-# weights/ranges. metabolic_heat_penalty is a regularisation term that breaks
-# degeneracy in cold conditions; the Q10 inequality constraint overrides it in
-# hot conditions. gradient_penalty (default 0) penalises deviation from the
-# target core–skin difference. skin_wetness_penalty > panting_penalty makes
-# panting activate before sweating.
-function _objective_value(effectors, opt)
+# =============================================================================
+# WeightedMeanNLP helpers
+#
+# Variables (9):
+#   x[1] = core_temperature (K)
+#   x[2] = skin_temperature (K)
+#   x[3] = insulation_temperature (K)
+#   x[4] = log(metabolic_heat_flow) (log W)
+#   x[5] = flesh_conductivity (W/m/K)
+#   x[6] = panting_rate (dimensionless)
+#   x[7] = skin_wetness (dimensionless)
+#   x[8] = insulation_depth (m)
+#   x[9] = axis_ratio_b (dimensionless)
+#
+# Constraints (4): residuals[1:3] == 0, residuals[4] >= 0 (Q10)
+# =============================================================================
+
+function _objective_value_weighted(effectors, opt)
     opt.core_temperature_penalty * ((effectors[1] - opt.setpoint_temperature_K) / opt.core_temperature_range)^2 +
     opt.metabolic_heat_penalty   * ((exp(effectors[4]) - opt.heat_flow_min_W)   / opt.heat_flow_range)^2        +
     opt.gradient_penalty         * ((effectors[1] - effectors[2] - opt.target_gradient) / opt.gradient_range)^2 +
@@ -34,13 +49,13 @@ function _objective_value(effectors, opt)
 end
 
 # Float64 effectors in → Unitful physics (via HeatExchange.nlp_residuals) → Float64 residuals out.
-# residuals[1:3] = 0 (energy balance, internal conduction, skin temp).
-# residuals[4]  >= 0 (Q10: metabolic_heat_flow >= Q_gen_min · q10^((T_core − T_setpoint)/10)).
-function _heat_balance_residuals!(residuals, effectors, p)
+# residuals[1:3] == 0 (energy balance, internal conduction, skin temp).
+# residuals[4]  >= 0 (Q10: metabolic_heat_flow >= minimum_heat_flow · q10^((T_core − T_setpoint)/10)).
+function _heat_balance_residuals_weighted!(residuals, effectors, p)
     core_temperature       = effectors[1] * u"K"
     skin_temperature       = effectors[2] * u"K"
     insulation_temperature = effectors[3] * u"K"
-    metabolic_heat_flow    = exp(effectors[4]) * u"W"   # effectors[4] = log(metabolic_heat_flow)
+    metabolic_heat_flow    = exp(effectors[4]) * u"W"
     flesh_conductivity     = effectors[5] * u"W/m/K"
     panting_rate           = effectors[6]
     skin_wetness           = effectors[7]
@@ -53,79 +68,23 @@ function _heat_balance_residuals!(residuals, effectors, p)
     residuals[1] = ustrip(u"W", r.residuals[1])   # energy_balance
     residuals[2] = ustrip(u"W", r.residuals[2])   # internal_conduction
     residuals[3] = ustrip(u"K", r.residuals[3])   # skin_temperature
-    residuals[4] = exp(effectors[4]) - p.Q_gen_min * p.q10 ^ ((effectors[1] - p.setpoint_temperature) / 10.0)
+    residuals[4] = exp(effectors[4]) - p.minimum_heat_flow * p.q10 ^ ((effectors[1] - p.setpoint_temperature) / 10.0)
     return nothing
 end
 
-"""
-    thermoregulate(::Endotherm, ::IPOPTControl, organism, environment,
-                   metabolic_heat_flow_init, skin_temperature_init,
-                   insulation_temperature_init; verbose=false)
-
-Solve endotherm heat balance as a nonlinear program via IPOPT.
-
-Uses nine NLP decision variables: six physiological effectors (metabolic heat
-generation, flesh conductivity, panting rate, skin wetness, insulation depth,
-body shape) plus three temperature state variables (core, skin, insulation surface).
-Three heat-balance equality constraints from `HeatExchange.nlp_residuals` enforce
-physical consistency so that the temperatures are outcomes of the effectors, not
-independent choices. A fourth inequality constraint enforces Q10 metabolic scaling:
-`metabolic_heat_flow >= heat_flow_min * Q10^((core_temperature − setpoint)/10)`.
-
-`metabolic_heat_flow` is not penalised in the objective — it is a state variable driven by the
-energy balance. The `core_temperature` term implicitly sets `metabolic_heat_flow`: in the cold it
-rises freely to close the deficit; in the heat it stays near `heat_flow_min` because extra heat
-would push `core_temperature` above setpoint. All penalty terms are normalised to [0,1].
-Penalty weights in `ThermoregulationLimits`:
-  - `core_temperature_penalty`  — lower → core_temperature rises sooner before effectors are exhausted
-  - `metabolic_heat_penalty`   — small regularisation (default 0.1) preventing high-panting/high-metabolic_heat_flow
-                                  degeneracy at cold temperatures; overridden at hot temperatures by
-                                  the Q10 inequality constraint which forces metabolic_heat_flow to rise
-  - `gradient_penalty`         — non-zero → penalise deviation from `target_core_skin_gradient`;
-                                  activates vasodilation/evaporation before core_temperature moves (default 0)
-  - `panting_penalty`          — lower → panting activates sooner
-  - `skin_wetness_penalty`     — higher than `panting_penalty` → panting activates before sweating
-
-# Arguments
-- `organism`: must have `OrganismTraits` with `ThermoregulationLimits`
-- `environment`: NamedTuple with `environment_pars` and `environment_vars`
-- `metabolic_heat_flow_init`: initial guess for metabolic heat generation (W)
-- `skin_temperature_init`: initial guess for skin temperature (K)
-- `insulation_temperature_init`: initial guess for insulation surface temperature (K)
-"""
-function thermoregulate(
-    ::Endotherm,
-    ::IPOPTControl,
-    organism::Organism,
-    environment::NamedTuple,
-    metabolic_heat_flow_init,
-    skin_temperature_init,
-    insulation_temperature_init;
-    verbose = false,
+function _run_ipopt(
+    nlp_packed::HeatExchange.WeightedMeanNLPPacked,
+    organism, environment, limits, metab_pars, int_cond, evap_pars,
+    metabolic_heat_flow_init, skin_temperature_init, insulation_temperature_init;
+    verbose,
 )
-    metab_pars = metabolism_pars(organism)
-    limits     = thermoregulation(organism)
-    int_cond   = conduction_pars_internal(organism)
-    evap_pars  = evaporation_pars(organism)
-    T_air      = environment.environment_vars.air_temperature
-    T_setpoint = metab_pars.core_temperature
-
-    # ---- Pre-solve physics packing ------------------------------------------
-    nlp_packed = HeatExchange.nlp_pack(WeightedMeanNLP(), organism, environment,
-                                       skin_temperature_init, insulation_temperature_init)
-
-    # ---- Boundary: strip into pure Float64 optimizer-world parameters --------
-    # x = [core_temperature, skin_temperature, insulation_temperature,    ← temperature states
-    #       log(metabolic_heat_flow), flesh_conductivity, panting_rate,   ← effectors
-    #       skin_wetness, insulation_depth, axis_ratio_b]                  ← effectors
-    # The three equality constraints make temperatures outcomes of the six effectors.
-    air_temperature_K      = ustrip(u"K", T_air)
-    setpoint_temperature_K = ustrip(u"K", T_setpoint)
+    air_temperature_K      = ustrip(u"K", environment.environment_vars.air_temperature)
+    setpoint_temperature_K = ustrip(u"K", metab_pars.core_temperature)
     core_temperature_min   = ustrip(u"K", limits.core_temperature.reference)
     core_temperature_max   = ustrip(u"K", limits.core_temperature.max)
     skin_temperature_min   = air_temperature_K - 5.0
     skin_temperature_max   = core_temperature_max + 5.0
-    heat_flow_min_W        = ustrip(u"W", limits.Q_minimum_ref)
+    heat_flow_min_W        = ustrip(u"W", limits.minimum_heat_flow)
     heat_flow_max_W        = heat_flow_min_W * 20.0
     log_heat_flow_min      = log(heat_flow_min_W)
     log_heat_flow_max      = log(heat_flow_max_W)
@@ -161,9 +120,6 @@ function thermoregulate(
         lower_bounds, upper_bounds,
     )
 
-    # gradient_range reuses core_temperature_range: max plausible deviation of
-    # (core_temperature − skin_temperature) from target equals the max core_temperature
-    # excursion above setpoint.
     core_temperature_range = max(core_temperature_max - setpoint_temperature_K, 1e-6)
     opt_pars = (;
         setpoint_temperature_K,
@@ -182,35 +138,25 @@ function thermoregulate(
         heat_flow_range          = max(heat_flow_max_W - heat_flow_min_W, 1.0),
     )
 
-    # nlp_packed carries physics; Q_gen_min/q10/setpoint_temperature are Q10 solver policy.
     nlp_pars = (;
         nlp_packed,
-        Q_gen_min            = heat_flow_min_W,
+        minimum_heat_flow    = heat_flow_min_W,
         q10                  = Float64(metab_pars.q10),
         setpoint_temperature = setpoint_temperature_K,
     )
 
-    # ---- Closures bridging IPOPT to the boundary helpers --------------------
-    # Each closure captures only the world it needs: `_objective_value` sees
-    # `opt_pars`, `_heat_balance_residuals!` sees `nlp_pars`. `nothing` is
-    # passed as Optimization's `p` since the closures already carry the params.
-    obj_fn(x, _) = _objective_value(x, opt_pars)
-    res_fn!(r, x, _) = _heat_balance_residuals!(r, x, nlp_pars)
-
-    # Bypass DifferentiationInterface (incompatible with Unitful params NamedTuple).
-    # hess! and cons_h! are registered (required by IpoptOptimizer) but not called
-    # at runtime when hessian_approximation="limited-memory" is set — L-BFGS builds
-    # the Hessian approximation from gradient differences, eliminating O(n²) evaluations.
-    grad_fn!(g, x, _) = FiniteDiff.finite_difference_gradient!(g, e -> _objective_value(e, opt_pars), x)
-    hess_fn!(H, x, _) = (H .= FiniteDiff.finite_difference_hessian(e -> _objective_value(e, opt_pars), x))
+    obj_fn(x, _)    = _objective_value_weighted(x, opt_pars)
+    res_fn!(r, x, _) = _heat_balance_residuals_weighted!(r, x, nlp_pars)
+    grad_fn!(g, x, _) = FiniteDiff.finite_difference_gradient!(g, e -> _objective_value_weighted(e, opt_pars), x)
+    hess_fn!(H, x, _) = (H .= FiniteDiff.finite_difference_hessian(e -> _objective_value_weighted(e, opt_pars), x))
     cons_j_fn!(J, x, _) = (J .= FiniteDiff.finite_difference_jacobian(
-        e -> (r = zeros(eltype(e), 4); _heat_balance_residuals!(r, e, nlp_pars); r),
+        e -> (r = zeros(eltype(e), 4); _heat_balance_residuals_weighted!(r, e, nlp_pars); r),
         x,
     ))
     function cons_h_fn!(res, x, _)
         for i in eachindex(res)
             res[i] .= FiniteDiff.finite_difference_hessian(
-                e -> (r = zeros(4); _heat_balance_residuals!(r, e, nlp_pars); r[i]),
+                e -> (r = zeros(4); _heat_balance_residuals_weighted!(r, e, nlp_pars); r[i]),
                 x,
             )
         end
@@ -227,10 +173,8 @@ function thermoregulate(
         lb     = lower_bounds,
         ub     = upper_bounds,
         lcons  = [0.0, 0.0, 0.0, 0.0],
-        ucons  = [0.0, 0.0, 0.0, Inf],  # residuals[4] >= 0: metabolic_heat_flow >= Q10-scaled minimum
+        ucons  = [0.0, 0.0, 0.0, Inf],
     )
-    # hessian_approximation and tolerance options go to the IpoptOptimizer struct (not solve kwargs).
-    # reltol and maxiters are common interface args forwarded via solve.
     ipopt_sol = solve(optimization_prob,
         IpoptOptimizer(;
             hessian_approximation = "limited-memory",
@@ -242,12 +186,11 @@ function thermoregulate(
         maxiters = 300,
     )
 
-    # ---- Boundary: attach units to solution, delegate output assembly --------
     x_sol = ipopt_sol.u
     core_temperature       = x_sol[1] * u"K"
     skin_temperature       = x_sol[2] * u"K"
     insulation_temperature = x_sol[3] * u"K"
-    metabolic_heat_flow    = exp(x_sol[4]) * u"W"   # x_sol[4] = log(metabolic_heat_flow)
+    metabolic_heat_flow    = exp(x_sol[4]) * u"W"
     flesh_conductivity     = x_sol[5] * u"W/m/K"
     panting_rate           = x_sol[6]
     skin_wetness           = x_sol[7]
@@ -257,4 +200,264 @@ function thermoregulate(
     return HeatExchange.nlp_assemble_output(nlp_pars.nlp_packed, organism, environment,
         core_temperature, skin_temperature, insulation_temperature, metabolic_heat_flow,
         flesh_conductivity, panting_rate, skin_wetness, insulation_depth, axis_ratio_b)
+end
+
+# =============================================================================
+# MultiSidedNLP helpers
+#
+# Variables (11):
+#   x[1]  = core_temperature (K)
+#   x[2]  = dorsal_skin_temperature (K)
+#   x[3]  = dorsal_insulation_temperature (K)
+#   x[4]  = ventral_skin_temperature (K)
+#   x[5]  = ventral_insulation_temperature (K)
+#   x[6]  = log(metabolic_heat_flow) (log W)
+#   x[7]  = flesh_conductivity (W/m/K)
+#   x[8]  = panting_rate (dimensionless)
+#   x[9]  = skin_wetness (dimensionless)
+#   x[10] = insulation_depth (m)
+#   x[11] = axis_ratio_b (dimensionless)
+#
+# Constraints (6): residuals[1:5] == 0, residuals[6] >= 0 (Q10)
+# =============================================================================
+
+function _objective_value_multisided(effectors, opt)
+    skin_temp_mean = (effectors[2] + effectors[4]) / 2
+    opt.core_temperature_penalty * ((effectors[1] - opt.setpoint_temperature_K) / opt.core_temperature_range)^2 +
+    opt.metabolic_heat_penalty   * ((exp(effectors[6]) - opt.heat_flow_min_W)   / opt.heat_flow_range)^2        +
+    opt.gradient_penalty         * ((effectors[1] - skin_temp_mean - opt.target_gradient) / opt.gradient_range)^2 +
+    opt.panting_penalty          * ((effectors[8] - 1.0) / opt.panting_rate_range)^2                            +
+    opt.skin_wetness_penalty     * ((effectors[9] - opt.skin_wetness_min) / opt.skin_wetness_range)^2
+end
+
+# residuals[1:5] == 0 (dorsal surface, dorsal skin, ventral surface, ventral skin, whole-organism).
+# residuals[6]  >= 0 (Q10: metabolic_heat_flow >= minimum_heat_flow · q10^((T_core − T_setpoint)/10)).
+function _heat_balance_residuals_multisided!(residuals, effectors, p)
+    core_temperature              = effectors[1]  * u"K"
+    dorsal_skin_temperature       = effectors[2]  * u"K"
+    dorsal_insulation_temperature = effectors[3]  * u"K"
+    ventral_skin_temperature      = effectors[4]  * u"K"
+    ventral_insulation_temperature = effectors[5] * u"K"
+    metabolic_heat_flow           = exp(effectors[6]) * u"W"
+    flesh_conductivity            = effectors[7]  * u"W/m/K"
+    panting_rate                  = effectors[8]
+    skin_wetness                  = effectors[9]
+    insulation_depth              = effectors[10] * u"m"
+    axis_ratio_b                  = effectors[11]
+
+    r = HeatExchange.nlp_residuals(p.nlp_packed, core_temperature,
+        dorsal_skin_temperature, dorsal_insulation_temperature,
+        ventral_skin_temperature, ventral_insulation_temperature,
+        metabolic_heat_flow, flesh_conductivity, panting_rate, skin_wetness,
+        insulation_depth, axis_ratio_b)
+    residuals[1] = ustrip(u"W", r.residuals[1])   # dorsal surface balance
+    residuals[2] = ustrip(u"K", r.residuals[2])   # dorsal skin temperature
+    residuals[3] = ustrip(u"W", r.residuals[3])   # ventral surface balance
+    residuals[4] = ustrip(u"K", r.residuals[4])   # ventral skin temperature
+    residuals[5] = ustrip(u"W", r.residuals[5])   # whole-organism balance
+    residuals[6] = exp(effectors[6]) - p.minimum_heat_flow * p.q10 ^ ((effectors[1] - p.setpoint_temperature) / 10.0)
+    return nothing
+end
+
+function _run_ipopt(
+    nlp_packed::HeatExchange.MultiSidedNLPPacked,
+    organism, environment, limits, metab_pars, int_cond, evap_pars,
+    metabolic_heat_flow_init, ::Any, ::Any;
+    verbose,
+)
+    air_temperature_K      = ustrip(u"K", environment.environment_vars.air_temperature)
+    setpoint_temperature_K = ustrip(u"K", metab_pars.core_temperature)
+    core_temperature_min   = ustrip(u"K", limits.core_temperature.reference)
+    core_temperature_max   = ustrip(u"K", limits.core_temperature.max)
+    skin_temperature_min   = air_temperature_K - 5.0
+    skin_temperature_max   = core_temperature_max + 5.0
+    heat_flow_min_W        = ustrip(u"W", limits.minimum_heat_flow)
+    heat_flow_max_W        = heat_flow_min_W * 20.0
+    log_heat_flow_min      = log(heat_flow_min_W)
+    log_heat_flow_max      = log(heat_flow_max_W)
+    flesh_conductivity_min = ustrip(u"W/m/K", limits.flesh_conductivity.reference)
+    flesh_conductivity_max = ustrip(u"W/m/K", limits.flesh_conductivity.max)
+    panting_rate_min       = 1.0
+    panting_rate_max       = Float64(limits.panting.pant.max)
+    skin_wetness_min       = Float64(limits.skin_wetness.reference)
+    skin_wetness_max       = Float64(limits.skin_wetness.max)
+    insulation_depth_min   = ustrip(u"m", limits.insulation.dorsal.reference)
+    insulation_depth_max   = ustrip(u"m", limits.insulation.dorsal.max)
+    aspect_ratio_min       = Float64(limits.aspect_ratio_factor.reference)
+    aspect_ratio_max       = organism.body.shape isa Sphere ? aspect_ratio_min : Float64(limits.aspect_ratio_factor.max)
+
+    lower_bounds = [core_temperature_min,
+                    skin_temperature_min, skin_temperature_min,   # dorsal skin, ins
+                    skin_temperature_min, skin_temperature_min,   # ventral skin, ins
+                    log_heat_flow_min,
+                    flesh_conductivity_min, panting_rate_min, skin_wetness_min,
+                    insulation_depth_min, aspect_ratio_min]
+    upper_bounds = [core_temperature_max,
+                    skin_temperature_max, skin_temperature_max,
+                    skin_temperature_max, skin_temperature_max,
+                    log_heat_flow_max,
+                    flesh_conductivity_max, panting_rate_max, skin_wetness_max,
+                    insulation_depth_max, aspect_ratio_max]
+
+    pp = nlp_packed.p
+    heat_flow_init = max(ustrip(u"W", metabolic_heat_flow_init), heat_flow_min_W)
+    initial_effectors = clamp.(
+        [setpoint_temperature_K,
+         ustrip(u"K", pp.initial_dorsal_skin_temperature),
+         ustrip(u"K", pp.initial_dorsal_insulation_temperature),
+         ustrip(u"K", pp.initial_ventral_skin_temperature),
+         ustrip(u"K", pp.initial_ventral_insulation_temperature),
+         log(heat_flow_init),
+         ustrip(u"W/m/K", int_cond.flesh_conductivity),
+         1.0,
+         Float64(evap_pars.skin_wetness),
+         insulation_depth_max,   # start with erected insulation
+         aspect_ratio_min],      # start curled
+        lower_bounds, upper_bounds,
+    )
+
+    core_temperature_range = max(core_temperature_max - setpoint_temperature_K, 1e-6)
+    opt_pars = (;
+        setpoint_temperature_K,
+        heat_flow_min_W,
+        core_temperature_penalty = limits.core_temperature_penalty,
+        metabolic_heat_penalty   = limits.metabolic_heat_penalty,
+        panting_penalty          = limits.panting_penalty,
+        skin_wetness_penalty     = limits.skin_wetness_penalty,
+        gradient_penalty         = limits.gradient_penalty,
+        target_gradient          = limits.target_core_skin_gradient,
+        core_temperature_range,
+        gradient_range           = core_temperature_range,
+        panting_rate_range       = max(panting_rate_max - 1.0, 1e-6),
+        skin_wetness_min,
+        skin_wetness_range       = max(skin_wetness_max - skin_wetness_min, 1e-6),
+        heat_flow_range          = max(heat_flow_max_W - heat_flow_min_W, 1.0),
+    )
+
+    nlp_pars = (;
+        nlp_packed,
+        minimum_heat_flow    = heat_flow_min_W,
+        q10                  = Float64(metab_pars.q10),
+        setpoint_temperature = setpoint_temperature_K,
+    )
+
+    obj_fn(x, _)     = _objective_value_multisided(x, opt_pars)
+    res_fn!(r, x, _) = _heat_balance_residuals_multisided!(r, x, nlp_pars)
+    grad_fn!(g, x, _) = FiniteDiff.finite_difference_gradient!(g, e -> _objective_value_multisided(e, opt_pars), x)
+    hess_fn!(H, x, _) = (H .= FiniteDiff.finite_difference_hessian(e -> _objective_value_multisided(e, opt_pars), x))
+    cons_j_fn!(J, x, _) = (J .= FiniteDiff.finite_difference_jacobian(
+        e -> (r = zeros(eltype(e), 6); _heat_balance_residuals_multisided!(r, e, nlp_pars); r),
+        x,
+    ))
+    function cons_h_fn!(res, x, _)
+        for i in eachindex(res)
+            res[i] .= FiniteDiff.finite_difference_hessian(
+                e -> (r = zeros(6); _heat_balance_residuals_multisided!(r, e, nlp_pars); r[i]),
+                x,
+            )
+        end
+    end
+
+    optimization_func = OptimizationFunction(obj_fn, SciMLBase.NoAD();
+        cons     = res_fn!,
+        grad     = grad_fn!,
+        hess     = hess_fn!,
+        cons_j   = cons_j_fn!,
+        cons_h   = cons_h_fn!,
+    )
+    optimization_prob = OptimizationProblem(optimization_func, initial_effectors, nothing;
+        lb     = lower_bounds,
+        ub     = upper_bounds,
+        lcons  = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ucons  = [0.0, 0.0, 0.0, 0.0, 0.0, Inf],
+    )
+    ipopt_sol = solve(optimization_prob,
+        IpoptOptimizer(;
+            hessian_approximation = "limited-memory",
+            acceptable_tol        = 1e-3,
+            acceptable_iter       = 5,
+        );
+        verbose,
+        reltol   = 1e-4,
+        maxiters = 300,
+    )
+
+    x_sol = ipopt_sol.u
+    core_temperature              = x_sol[1]  * u"K"
+    dorsal_skin_temperature       = x_sol[2]  * u"K"
+    dorsal_insulation_temperature = x_sol[3]  * u"K"
+    ventral_skin_temperature      = x_sol[4]  * u"K"
+    ventral_insulation_temperature = x_sol[5] * u"K"
+    metabolic_heat_flow           = exp(x_sol[6]) * u"W"
+    flesh_conductivity            = x_sol[7]  * u"W/m/K"
+    panting_rate                  = x_sol[8]
+    skin_wetness                  = x_sol[9]
+    insulation_depth              = x_sol[10] * u"m"
+    axis_ratio_b                  = x_sol[11]
+
+    return HeatExchange.nlp_assemble_output(nlp_pars.nlp_packed, organism, environment,
+        core_temperature,
+        dorsal_skin_temperature, dorsal_insulation_temperature,
+        ventral_skin_temperature, ventral_insulation_temperature,
+        metabolic_heat_flow, flesh_conductivity, panting_rate, skin_wetness,
+        insulation_depth, axis_ratio_b)
+end
+
+# =============================================================================
+# Main thermoregulate dispatch
+# =============================================================================
+
+"""
+    thermoregulate(::Endotherm, ::IPOPTControl, organism, environment,
+                   metabolic_heat_flow_init, skin_temperature_init,
+                   insulation_temperature_init; verbose=false)
+
+Solve endotherm heat balance as a nonlinear program via IPOPT.
+
+The NLP formulation is selected by `IPOPTControl.nlp_strategy`:
+- `WeightedMeanNLP()` (default): dorsal/ventral weighted-mean single-body formulation.
+  Nine decision variables, four constraints (three equality + Q10 inequality).
+- `MultiSidedNLP()`: explicit per-side heat balance. Eleven decision variables, six
+  constraints (five equality + Q10 inequality). Per-side skin and insulation temperatures
+  are independent decision variables, giving the solver more freedom to represent
+  asymmetric environmental loading (sun above, ground below).
+
+Both formulations penalise deviation from the setpoint core temperature and enforce
+`metabolic_heat_flow >= heat_flow_min * Q10^((core_temperature − setpoint)/10)`.
+Penalty weights in `ThermoregulationLimits`:
+  - `core_temperature_penalty`  — lower → core_temperature rises sooner before effectors are exhausted
+  - `metabolic_heat_penalty`   — small regularisation (default 0.1) preventing high-panting/high-metabolic_heat_flow
+                                  degeneracy at cold temperatures; overridden at hot temperatures by Q10 constraint
+  - `gradient_penalty`         — non-zero → penalise deviation from `target_core_skin_gradient`
+  - `panting_penalty`          — lower → panting activates sooner
+  - `skin_wetness_penalty`     — higher than `panting_penalty` → panting activates before sweating
+
+# Arguments
+- `organism`: must have `OrganismTraits` with `ThermoregulationLimits`
+- `environment`: NamedTuple with `environment_pars` and `environment_vars`
+- `metabolic_heat_flow_init`: initial guess for metabolic heat generation (W)
+- `skin_temperature_init`: initial guess for skin temperature (K)
+- `insulation_temperature_init`: initial guess for insulation surface temperature (K)
+"""
+function thermoregulate(
+    ::Endotherm,
+    control::IPOPTControl,
+    organism::Organism,
+    environment::NamedTuple,
+    metabolic_heat_flow_init,
+    skin_temperature_init,
+    insulation_temperature_init;
+    verbose = false,
+)
+    metab_pars = metabolism_pars(organism)
+    limits     = thermoregulation(organism)
+    int_cond   = conduction_pars_internal(organism)
+    evap_pars  = evaporation_pars(organism)
+
+    nlp_packed = HeatExchange.nlp_pack(control.nlp_strategy, organism, environment,
+                                       skin_temperature_init, insulation_temperature_init)
+
+    _run_ipopt(nlp_packed, organism, environment, limits, metab_pars, int_cond, evap_pars,
+               metabolic_heat_flow_init, skin_temperature_init, insulation_temperature_init;
+               verbose)
 end

--- a/src/endotherm/thermoregulation/ipopt.jl
+++ b/src/endotherm/thermoregulation/ipopt.jl
@@ -1,15 +1,10 @@
 # =============================================================================
 # IPOPT-based endotherm thermoregulation control.
 #
-# Solves the heat balance as a constrained nonlinear program with nine
-# decision variables (six effectors + three temperature states), three
-# heat-balance equality constraints, and a Q10 metabolic-scaling
-# inequality constraint. Uses a single mean-weighted body geometry rather
-# than separate dorsal/ventral solves.
-#
-# HeatExchange-mirror helpers (`view_factor_decomposition`, `solar_heat_flows`,
-# `pack_heat_balance_env`, `pack_heat_balance_traits`, `longwave_output_flows`)
-# live in `heatexchange.jl` until HeatExchange.jl exports them.
+# Solver policy lives here: objective, variable bounds, initial effectors, and
+# the Q10 metabolic-scaling inequality constraint.
+# All physics (packing, per-iteration residuals, output assembly) is delegated
+# to HeatExchange.nlp_pack / nlp_residuals / nlp_assemble_output.
 # =============================================================================
 
 # =============================================================================
@@ -22,27 +17,7 @@
 #   `_heat_balance_residuals!` is the *only* function that crosses the
 #       boundary: Float64 effectors in, Float64 residuals out, Unitful science
 #       in between. Units are attached at the top, stripped at the bottom.
-#
-# All other helpers (`_build_trial_geometry`, `q10_scale`, `heat_balance`,
-# longwave/respiration calculations) operate exclusively on Unitful values.
 # =============================================================================
-
-# Trial body, insulation, and geometry from Unitful effector values.
-function _build_trial_geometry(sci, insulation_depth, aspect_ratio_factor,
-                               skin_temperature, insulation_temperature)
-    fibre_props = setproperties(sci.mean_fibre_props; depth = insulation_depth)
-    ins_pars    = setproperties(sci.mean_ins_pars; dorsal = fibre_props, ventral = fibre_props)
-    fur         = Fur(insulation_depth, sci.mean_fibre_props.diameter, sci.mean_fibre_props.density)
-    shape       = sci.body_is_sphere ? sci.body_shape :
-                  setproperties(sci.body_shape; aspect_ratio_b = aspect_ratio_factor)
-    body        = rebuild_body(shape, fur, sci.fat)
-    mean_T      = insulation_temperature * 0.7 + skin_temperature * 0.3
-    ins_props   = insulation_properties(ins_pars, mean_T, sci.ventral_fraction)
-    cond_area   = BiophysicalGeometry.total_area(body) * sci.ext_cond.conduction_fraction * 2
-    cond_coeff  = (cond_area * sci.substrate_conductivity) / sci.conduction_depth * sci.ventral_weight
-    geom_vars   = setproperties(sci.geometry_vars; conductance_coefficient = cond_coeff)
-    return (; body, ins_pars, insulation_props = ins_props, geometry_vars = geom_vars)
-end
 
 # Pure Float64 objective. `opt` carries only stripped scalars and dimensionless
 # weights/ranges. metabolic_heat_penalty is a regularisation term that breaks
@@ -58,50 +33,33 @@ function _objective_value(effectors, opt)
     opt.skin_wetness_penalty     * ((effectors[7] - opt.skin_wetness_min) / opt.skin_wetness_range)^2
 end
 
-# Boundary function. Float64 effectors in (top: attach units), Unitful science
-# in the middle, Float64 residuals out (bottom: strip units).
+# Float64 effectors in → Unitful physics (via HeatExchange.nlp_residuals) → Float64 residuals out.
 # residuals[1:3] = 0 (energy balance, internal conduction, skin temp).
-# residuals[4]  >= 0 (Q10: generated_heat_flow >= Q_minimum_ref · Q10^((T_core − T_setpoint)/10)).
-function _heat_balance_residuals!(residuals, effectors, sci)
+# residuals[4]  >= 0 (Q10: metabolic_heat_flow >= Q_gen_min · q10^((T_core − T_setpoint)/10)).
+function _heat_balance_residuals!(residuals, effectors, p)
     core_temperature       = effectors[1] * u"K"
     skin_temperature       = effectors[2] * u"K"
     insulation_temperature = effectors[3] * u"K"
-    generated_heat_flow    = exp(effectors[4]) * u"W"   # effectors[4] = log(generated_heat_flow)
+    metabolic_heat_flow    = exp(effectors[4]) * u"W"   # effectors[4] = log(metabolic_heat_flow)
     flesh_conductivity     = effectors[5] * u"W/m/K"
     panting_rate           = effectors[6]
     skin_wetness           = effectors[7]
     insulation_depth       = effectors[8] * u"m"
-    aspect_ratio_factor    = effectors[9]
+    axis_ratio_b           = effectors[9]
 
-    trial = _build_trial_geometry(sci, insulation_depth, aspect_ratio_factor,
-                                  skin_temperature, insulation_temperature)
-
-    balance = HeatExchange.heat_balance(
-        core_temperature, skin_temperature, insulation_temperature, generated_heat_flow;
-        body             = trial.body,
-        insulation_pars  = trial.ins_pars,
-        insulation       = trial.insulation_props,
-        geometry_vars    = trial.geometry_vars,
-        environment_vars = sci.heat_balance_env,
-        traits           = sci.heat_balance_traits,
-        resp_pars        = sci.resp_pars,
-        k_flesh          = flesh_conductivity,
-        pant             = panting_rate,
-        skin_wetness,
-    )
-    q10_minimum = sci.Q_minimum_ref *
-                  q10_scale(sci.q10, core_temperature, sci.setpoint_temperature)
-
-    residuals[1] = ustrip(u"W", balance.residual_energy_balance)
-    residuals[2] = ustrip(u"W", balance.residual_internal_conduction)
-    residuals[3] = ustrip(u"K", balance.residual_skin_temperature)
-    residuals[4] = ustrip(u"W", generated_heat_flow - q10_minimum)
+    r = HeatExchange.nlp_residuals(p.nlp_packed, core_temperature, skin_temperature,
+        insulation_temperature, metabolic_heat_flow, flesh_conductivity,
+        panting_rate, skin_wetness, insulation_depth, axis_ratio_b)
+    residuals[1] = ustrip(u"W", r.residuals[1])   # energy_balance
+    residuals[2] = ustrip(u"W", r.residuals[2])   # internal_conduction
+    residuals[3] = ustrip(u"K", r.residuals[3])   # skin_temperature
+    residuals[4] = exp(effectors[4]) - p.Q_gen_min * p.q10 ^ ((effectors[1] - p.setpoint_temperature) / 10.0)
     return nothing
 end
 
 """
     thermoregulate(::Endotherm, ::IPOPTControl, organism, environment,
-                   generated_heat_flow_init, skin_temperature_init,
+                   metabolic_heat_flow_init, skin_temperature_init,
                    insulation_temperature_init; verbose=false)
 
 Solve endotherm heat balance as a nonlinear program via IPOPT.
@@ -109,32 +67,29 @@ Solve endotherm heat balance as a nonlinear program via IPOPT.
 Uses nine NLP decision variables: six physiological effectors (metabolic heat
 generation, flesh conductivity, panting rate, skin wetness, insulation depth,
 body shape) plus three temperature state variables (core, skin, insulation surface).
-Three heat-balance equality constraints from `HeatExchange.heat_balance` enforce
+Three heat-balance equality constraints from `HeatExchange.nlp_residuals` enforce
 physical consistency so that the temperatures are outcomes of the effectors, not
 independent choices. A fourth inequality constraint enforces Q10 metabolic scaling:
-`generated_heat_flow >= heat_flow_min * Q10^((core_temperature − setpoint)/10)`.
+`metabolic_heat_flow >= heat_flow_min * Q10^((core_temperature − setpoint)/10)`.
 
-`generated_heat_flow` is not penalised in the objective — it is a state variable driven by the
-energy balance. The `core_temperature` term implicitly sets `generated_heat_flow`: in the cold it
+`metabolic_heat_flow` is not penalised in the objective — it is a state variable driven by the
+energy balance. The `core_temperature` term implicitly sets `metabolic_heat_flow`: in the cold it
 rises freely to close the deficit; in the heat it stays near `heat_flow_min` because extra heat
 would push `core_temperature` above setpoint. All penalty terms are normalised to [0,1].
 Penalty weights in `ThermoregulationLimits`:
   - `core_temperature_penalty`  — lower → core_temperature rises sooner before effectors are exhausted
-  - `metabolic_heat_penalty`   — small regularisation (default 0.1) preventing high-panting/high-generated_heat_flow
+  - `metabolic_heat_penalty`   — small regularisation (default 0.1) preventing high-panting/high-metabolic_heat_flow
                                   degeneracy at cold temperatures; overridden at hot temperatures by
-                                  the Q10 inequality constraint which forces generated_heat_flow to rise
+                                  the Q10 inequality constraint which forces metabolic_heat_flow to rise
   - `gradient_penalty`         — non-zero → penalise deviation from `target_core_skin_gradient`;
                                   activates vasodilation/evaporation before core_temperature moves (default 0)
   - `panting_penalty`          — lower → panting activates sooner
   - `skin_wetness_penalty`     — higher than `panting_penalty` → panting activates before sweating
 
-Uses a dorsal/ventral mean-weighted body where dorsal_weight = sky_view_factor +
-vegetation_view_factor. This matches the weighting used by `solve_metabolic_rate`.
-
 # Arguments
 - `organism`: must have `OrganismTraits` with `ThermoregulationLimits`
 - `environment`: NamedTuple with `environment_pars` and `environment_vars`
-- `generated_heat_flow_init`: initial guess for metabolic heat generation (W)
+- `metabolic_heat_flow_init`: initial guess for metabolic heat generation (W)
 - `skin_temperature_init`: initial guess for skin temperature (K)
 - `insulation_temperature_init`: initial guess for insulation surface temperature (K)
 """
@@ -143,124 +98,26 @@ function thermoregulate(
     ::IPOPTControl,
     organism::Organism,
     environment::NamedTuple,
-    generated_heat_flow_init,
+    metabolic_heat_flow_init,
     skin_temperature_init,
     insulation_temperature_init;
     verbose = false,
 )
-    env_pars  = stripparams(environment.environment_pars)
-    env_vars  = environment.environment_vars
-
-    ins_pars   = insulation_pars(organism)
-    ext_cond   = conduction_pars_external(organism)
-    int_cond   = conduction_pars_internal(organism)
-    rad_pars   = radiation_pars(organism)
-    evap_pars  = evaporation_pars(organism)
-    resp_pars  = respiration_pars(organism)
     metab_pars = metabolism_pars(organism)
     limits     = thermoregulation(organism)
+    int_cond   = conduction_pars_internal(organism)
+    evap_pars  = evaporation_pars(organism)
+    T_air      = environment.environment_vars.air_temperature
+    T_setpoint = metab_pars.core_temperature
 
-    T_air        = env_vars.air_temperature
-    T_setpoint   = metab_pars.core_temperature
-    T_vegetation = env_vars.reference_air_temperature
-
-    # ---- View factor decomposition + dorsal/ventral weights -----------------
-    view_factors     = view_factor_decomposition(rad_pars, env_vars)
-    dorsal_weight    = view_factors.sky + view_factors.vegetation
-    ventral_weight   = 1 - dorsal_weight
-    ventral_fraction = rad_pars.ventral_fraction
-
-    # ---- Mean-weighted insulation geometry (IPOPT-specific averaging) -------
-    fat = Fat(int_cond.fat_fraction, int_cond.fat_density)
-
-    mean_insulation_depth   = ins_pars.dorsal.depth        * dorsal_weight + ins_pars.ventral.depth        * ventral_weight
-    mean_fibre_diameter     = ins_pars.dorsal.diameter     * dorsal_weight + ins_pars.ventral.diameter     * ventral_weight
-    mean_fibre_density      = ins_pars.dorsal.density      * dorsal_weight + ins_pars.ventral.density      * ventral_weight
-    mean_fibre_length       = ins_pars.dorsal.length       * dorsal_weight + ins_pars.ventral.length       * ventral_weight
-    mean_fibre_reflectance  = ins_pars.dorsal.reflectance  * dorsal_weight + ins_pars.ventral.reflectance  * ventral_weight
-    mean_fibre_conductivity = ins_pars.dorsal.conductivity * dorsal_weight + ins_pars.ventral.conductivity * ventral_weight
-
-    mean_fibre_props = FibreProperties(;
-        diameter     = mean_fibre_diameter,
-        length       = mean_fibre_length,
-        density      = mean_fibre_density,
-        depth        = mean_insulation_depth,
-        reflectance  = mean_fibre_reflectance,
-        conductivity = mean_fibre_conductivity,
-    )
-    mean_ins_pars = InsulationParameters(;
-        dorsal                  = mean_fibre_props,
-        ventral                 = mean_fibre_props,
-        depth_compressed        = ins_pars.depth_compressed,
-        longwave_depth_fraction = ins_pars.longwave_depth_fraction,
-    )
-    mean_fur  = Fur(mean_insulation_depth, mean_fibre_diameter, mean_fibre_density)
-    mean_body = rebuild_body(organism.body.shape, mean_fur, fat)
-
-    # ---- Solar heat flows (dorsal/ventral split + mean) ---------------------
-    solar_result    = solar_heat_flows(organism.body, rad_pars, env_pars, env_vars,
-                                       view_factors, ext_cond.conduction_fraction)
-    mean_solar_flow = solar_result.dorsal * dorsal_weight + solar_result.ventral * ventral_weight
-
-    # ---- Mean radiation view factors: dorsal sees sky+veg, ventral sees ground+bush
-    mean_view_factors = ViewFactors(
-        view_factors.sky        * 2.0 * dorsal_weight,
-        view_factors.ground     * 2.0 * ventral_weight,
-        view_factors.bush       * 2.0 * ventral_weight,
-        view_factors.vegetation * 2.0,
-    )
-
-    # ---- Mean substrate conductance (ventral side only) ---------------------
-    mean_body_total_area     = BiophysicalGeometry.total_area(mean_body)
-    ventral_conduction_area  = mean_body_total_area * ext_cond.conduction_fraction * 2
-    ventral_conduction_coeff = (ventral_conduction_area * env_vars.substrate_conductivity) /
-                               env_pars.conduction_depth
-    mean_conduction_coeff    = ventral_conduction_coeff * ventral_weight
-
-    # ---- Pack environment, traits, geometry for HeatExchange.heat_balance ---
-    mean_insulation_temperature_init = insulation_temperature_init * 0.7 + skin_temperature_init * 0.3
-    insulation_props_init = insulation_properties(mean_ins_pars, mean_insulation_temperature_init, ventral_fraction)
-
-    heat_balance_env = pack_heat_balance_env(env_vars, env_pars, mean_view_factors,
-                                             T_vegetation, mean_solar_flow)
-
-    mean_body_emissivity = rad_pars.body_emissivity_dorsal * dorsal_weight +
-                           rad_pars.body_emissivity_ventral * ventral_weight
-    heat_balance_traits = pack_heat_balance_traits(int_cond, evap_pars, mean_body_emissivity)
-
-    geometry_vars = GeometryVariables(;
-        side                    = :dorsal,
-        conductance_coefficient = mean_conduction_coeff,
-        ventral_fraction,
-        conduction_fraction     = ext_cond.conduction_fraction,
-        longwave_depth_fraction = ins_pars.longwave_depth_fraction,
-    )
-
-    # ---- Unitful: scientific-world parameters --------------------------------
-    sci_pars = (;
-        setpoint_temperature   = T_setpoint,
-        Q_minimum_ref          = limits.Q_minimum_ref,
-        q10                    = metab_pars.q10,
-        mean_ins_pars,
-        mean_fibre_props,
-        fat,
-        body_shape             = organism.body.shape,
-        body_is_sphere         = organism.body.shape isa Sphere,
-        geometry_vars,
-        heat_balance_env,
-        heat_balance_traits,
-        resp_pars,
-        ventral_fraction,
-        substrate_conductivity = env_vars.substrate_conductivity,
-        conduction_depth       = env_pars.conduction_depth,
-        ventral_weight,
-        ext_cond,
-    )
+    # ---- Pre-solve physics packing ------------------------------------------
+    nlp_packed = HeatExchange.nlp_pack(WeightedMeanNLP(), organism, environment,
+                                       skin_temperature_init, insulation_temperature_init)
 
     # ---- Boundary: strip into pure Float64 optimizer-world parameters --------
     # x = [core_temperature, skin_temperature, insulation_temperature,    ← temperature states
-    #       log(generated_heat_flow), flesh_conductivity, panting_rate,   ← effectors
-    #       skin_wetness, insulation_depth, aspect_ratio_factor]           ← effectors
+    #       log(metabolic_heat_flow), flesh_conductivity, panting_rate,   ← effectors
+    #       skin_wetness, insulation_depth, axis_ratio_b]                  ← effectors
     # The three equality constraints make temperatures outcomes of the six effectors.
     air_temperature_K      = ustrip(u"K", T_air)
     setpoint_temperature_K = ustrip(u"K", T_setpoint)
@@ -290,7 +147,7 @@ function thermoregulate(
                     flesh_conductivity_max, panting_rate_max, skin_wetness_max,
                     insulation_depth_max, aspect_ratio_max]
 
-    heat_flow_init = max(ustrip(u"W", generated_heat_flow_init), heat_flow_min_W)
+    heat_flow_init = max(ustrip(u"W", metabolic_heat_flow_init), heat_flow_min_W)
     initial_effectors = clamp.(
         [setpoint_temperature_K,
          ustrip(u"K", skin_temperature_init),
@@ -325,12 +182,20 @@ function thermoregulate(
         heat_flow_range          = max(heat_flow_max_W - heat_flow_min_W, 1.0),
     )
 
+    # nlp_packed carries physics; Q_gen_min/q10/setpoint_temperature are Q10 solver policy.
+    nlp_pars = (;
+        nlp_packed,
+        Q_gen_min            = heat_flow_min_W,
+        q10                  = Float64(metab_pars.q10),
+        setpoint_temperature = setpoint_temperature_K,
+    )
+
     # ---- Closures bridging IPOPT to the boundary helpers --------------------
     # Each closure captures only the world it needs: `_objective_value` sees
-    # `opt_pars`, `_heat_balance_residuals!` sees `sci_pars`. `nothing` is
+    # `opt_pars`, `_heat_balance_residuals!` sees `nlp_pars`. `nothing` is
     # passed as Optimization's `p` since the closures already carry the params.
     obj_fn(x, _) = _objective_value(x, opt_pars)
-    res_fn!(r, x, _) = _heat_balance_residuals!(r, x, sci_pars)
+    res_fn!(r, x, _) = _heat_balance_residuals!(r, x, nlp_pars)
 
     # Bypass DifferentiationInterface (incompatible with Unitful params NamedTuple).
     # hess! and cons_h! are registered (required by IpoptOptimizer) but not called
@@ -339,13 +204,13 @@ function thermoregulate(
     grad_fn!(g, x, _) = FiniteDiff.finite_difference_gradient!(g, e -> _objective_value(e, opt_pars), x)
     hess_fn!(H, x, _) = (H .= FiniteDiff.finite_difference_hessian(e -> _objective_value(e, opt_pars), x))
     cons_j_fn!(J, x, _) = (J .= FiniteDiff.finite_difference_jacobian(
-        e -> (r = zeros(eltype(e), 4); _heat_balance_residuals!(r, e, sci_pars); r),
+        e -> (r = zeros(eltype(e), 4); _heat_balance_residuals!(r, e, nlp_pars); r),
         x,
     ))
     function cons_h_fn!(res, x, _)
         for i in eachindex(res)
             res[i] .= FiniteDiff.finite_difference_hessian(
-                e -> (r = zeros(4); _heat_balance_residuals!(r, e, sci_pars); r[i]),
+                e -> (r = zeros(4); _heat_balance_residuals!(r, e, nlp_pars); r[i]),
                 x,
             )
         end
@@ -362,7 +227,7 @@ function thermoregulate(
         lb     = lower_bounds,
         ub     = upper_bounds,
         lcons  = [0.0, 0.0, 0.0, 0.0],
-        ucons  = [0.0, 0.0, 0.0, Inf],  # residuals[4] >= 0: generated_heat_flow >= Q10-scaled minimum
+        ucons  = [0.0, 0.0, 0.0, Inf],  # residuals[4] >= 0: metabolic_heat_flow >= Q10-scaled minimum
     )
     # hessian_approximation and tolerance options go to the IpoptOptimizer struct (not solve kwargs).
     # reltol and maxiters are common interface args forwarded via solve.
@@ -377,135 +242,19 @@ function thermoregulate(
         maxiters = 300,
     )
 
-    # ---- Boundary: attach units to solution ----------------------------------
+    # ---- Boundary: attach units to solution, delegate output assembly --------
     x_sol = ipopt_sol.u
     core_temperature       = x_sol[1] * u"K"
     skin_temperature       = x_sol[2] * u"K"
     insulation_temperature = x_sol[3] * u"K"
-    generated_heat_flow    = exp(x_sol[4]) * u"W"   # x_sol[4] = log(generated_heat_flow)
+    metabolic_heat_flow    = exp(x_sol[4]) * u"W"   # x_sol[4] = log(metabolic_heat_flow)
     flesh_conductivity     = x_sol[5] * u"W/m/K"
     panting_rate           = x_sol[6]
     skin_wetness           = x_sol[7]
     insulation_depth       = x_sol[8] * u"m"
-    aspect_ratio_factor    = x_sol[9]
+    axis_ratio_b           = x_sol[9]
 
-    # ---- Unitful: reconstruct outputs ----------------------------------------
-    sol = _build_trial_geometry(sci_pars, insulation_depth, aspect_ratio_factor,
-                                skin_temperature, insulation_temperature)
-    sol_body             = sol.body
-    sol_ins_pars         = sol.ins_pars
-    sol_insulation_props = sol.insulation_props
-    sol_geometry_vars    = sol.geometry_vars
-
-    heat_balance_result = HeatExchange.heat_balance(
-        core_temperature, skin_temperature, insulation_temperature, generated_heat_flow;
-        body             = sol_body,
-        insulation_pars  = sol_ins_pars,
-        insulation       = sol_insulation_props,
-        geometry_vars    = sol_geometry_vars,
-        environment_vars = heat_balance_env,
-        traits           = heat_balance_traits,
-        resp_pars,
-        k_flesh          = flesh_conductivity,
-        pant             = panting_rate,
-        skin_wetness,
-    )
-
-    lung_temperature = (core_temperature + skin_temperature) / 2
-
-    # ---- Longwave flows -----------------------------------------------------
-    longwave = longwave_output_flows(sol_body, rad_pars, ext_cond.conduction_fraction,
-                                     view_factors, insulation_temperature, insulation_temperature)
-    longwave_flow_out = longwave.dorsal * dorsal_weight + longwave.ventral * ventral_weight
-    longwave_flow_in  = longwave_flow_out - heat_balance_result.radiation_heat_flow
-
-    # ---- Respiration mass flows at solution ----------------------------------
-    panting_resp_pars  = setproperties(resp_pars; pant = panting_rate)
-    respiration_result = HeatExchange.respiration(
-        MetabolicRates(; metabolic = generated_heat_flow, sum = generated_heat_flow, minimum = 0.0u"W"),
-        panting_resp_pars,
-        heat_balance_env.atmos,
-        organism.body.shape.mass,
-        lung_temperature,
-        T_air;
-        gas_fractions = env_pars.gas_fractions,
-        O2conversion  = Kleiber1961(),
-    )
-    latent_heat_vaporisation = FluidProperties.enthalpy_of_vaporisation(T_air)
-    m_sweat = u"g/hr"(heat_balance_result.skin_evaporation_heat_flow / latent_heat_vaporisation)
-    m_evap  = u"g/hr"(respiration_result.respiration_mass + m_sweat)
-
-    # ---- Assemble outputs matching solve_metabolic_rate structure ------------
-    thermoregulation_out = (;
-        core_temperature,
-        skin_temperature,
-        insulation_temperature,
-        lung_temperature,
-        skin_temperature_dorsal        = skin_temperature,
-        skin_temperature_ventral       = skin_temperature,
-        insulation_temperature_dorsal  = insulation_temperature,
-        insulation_temperature_ventral = insulation_temperature,
-        shape_b                        = aspect_ratio_factor,
-        pant                           = panting_rate,
-        skin_wetness,
-        flesh_conductivity,
-        insulation_conductivity_effective  = sol_insulation_props.conductivities.average,
-        insulation_conductivity_dorsal     = sol_insulation_props.conductivities.dorsal,
-        insulation_conductivity_ventral    = sol_insulation_props.conductivities.ventral,
-        insulation_conductivity_compressed = sol_insulation_props.conductivity_compressed,
-        insulation_depth_dorsal  = sol_ins_pars.dorsal.depth,
-        insulation_depth_ventral = sol_ins_pars.ventral.depth,
-        metab_pars.q10,
-    )
-
-    sol_total_area_out   = BiophysicalGeometry.total_area(sol_body)
-    area_skin_out        = skin_area(sol_body)
-    area_evaporation_out = evaporation_area(sol_body)
-    area_convection_out  = sol_total_area_out * (1 - ext_cond.conduction_fraction)
-    area_silhouette_out  = silhouette_area(sol_body, rad_pars.solar_orientation)
-    reference_total_area      = BiophysicalGeometry.total_area(organism.body)
-    reference_conduction_area = reference_total_area * ext_cond.conduction_fraction
-
-    morphology = (;
-        total_area               = sol_total_area_out,
-        area_skin                = area_skin_out,
-        area_evaporation         = area_evaporation_out,
-        area_convection          = area_convection_out,
-        area_conduction          = reference_conduction_area / 2,
-        area_silhouette          = area_silhouette_out,
-        sky_view_factor          = view_factors.sky,
-        ground_view_factor       = view_factors.ground,
-        volume                   = sol_body.geometry.volume,
-        volume_flesh             = flesh_volume(sol_body),
-        characteristic_dimension = HeatExchange.characteristic_dimension(HeatExchange.VolumeCubeRoot(), sol_body),
-        fat_mass                 = sol_body.shape.mass * fat.fraction,
-        sol_body.geometry.length...,
-    )
-
-    energy_flows = (;
-        solar_flow            = heat_balance_result.solar_heat_flow,
-        longwave_flow_in,
-        generated_heat_flow,
-        evaporation_heat_flow = heat_balance_result.skin_evaporation_heat_flow +
-                                heat_balance_result.insulation_evaporation_heat_flow +
-                                heat_balance_result.respiration_heat_flow,
-        longwave_flow_out,
-        convection_heat_flow  = heat_balance_result.convection_heat_flow,
-        conduction_flow       = heat_balance_result.conduction_heat_flow,
-        balance               = heat_balance_result.residual_energy_balance,
-        ntry                  = 1,
-        success               = true,
-    )
-
-    mass_flows = (;
-        air_flow             = respiration_result.air_flow,
-        oxygen_flow_standard = respiration_result.oxygen_flow_standard,
-        m_evap,
-        respiration_mass     = respiration_result.respiration_mass,
-        m_sweat,
-        molar_fluxes_in      = respiration_result.molar_fluxes_in,
-        molar_fluxes_out     = respiration_result.molar_fluxes_out,
-    )
-
-    return ThermoregulationOutput(thermoregulation_out, morphology, energy_flows, mass_flows)
+    return HeatExchange.nlp_assemble_output(nlp_pars.nlp_packed, organism, environment,
+        core_temperature, skin_temperature, insulation_temperature, metabolic_heat_flow,
+        flesh_conductivity, panting_rate, skin_wetness, insulation_depth, axis_ratio_b)
 end

--- a/src/endotherm/thermoregulation/rulebased.jl
+++ b/src/endotherm/thermoregulation/rulebased.jl
@@ -76,7 +76,7 @@ function uncurl(organism::Organism, aspect_ratio_limits::SteppedParameter)
     aspect_ratio_factor = min(aspect_ratio_limits.current + aspect_ratio_limits.step, aspect_ratio_limits.max)
     aspect_ratio_limits = @set aspect_ratio_limits.current = aspect_ratio_factor
 
-    new_shape_pars = @set shape_pars.aspect_ratio_b = aspect_ratio_factor
+    new_shape_pars = @set shape_pars.axis_ratio_b = aspect_ratio_factor
     fat = BiophysicalGeometry.inner_insulation(organism.body.insulation)
     fur = BiophysicalGeometry.outer_insulation(organism.body.insulation)
     geometry = rebuild_body(new_shape_pars, fur, fat)
@@ -173,7 +173,7 @@ end
 
 """
     thermoregulate(::Endotherm, ::RuleBasedSequentialControl, organism, environment,
-                   generated_heat_flow, skin_temperature, insulation_temperature)
+                   metabolic_heat_flow, skin_temperature, insulation_temperature)
 
 Run the endotherm thermoregulation loop using rule-based sequential control.
 
@@ -192,7 +192,7 @@ function thermoregulate(
     ::RuleBasedSequentialControl,
     organism::Organism,
     environment::NamedTuple,
-    generated_heat_flow,
+    metabolic_heat_flow,
     skin_temperature,
     insulation_temperature,
 )
@@ -226,13 +226,13 @@ function thermoregulate(
     endotherm_out    = solve_metabolic_rate(organism, environment, skin_temperature, insulation_temperature)
     skin_temperature = endotherm_out.thermoregulation.skin_temperature
     insulation_temperature = endotherm_out.thermoregulation.insulation_temperature
-    generated_heat_flow = endotherm_out.energy_flows.generated_heat_flow
+    metabolic_heat_flow = endotherm_out.energy_flows.metabolic_heat_flow
 
     Q_minimum = limits.Q_minimum_ref
 
     iteration = 0
 
-    while generated_heat_flow < Q_minimum * (1 - tolerance)
+    while metabolic_heat_flow < Q_minimum * (1 - tolerance)
         iteration += 1
         if iteration > max_iterations
             @warn "max_iterations exceeded"
@@ -288,7 +288,7 @@ function thermoregulate(
         endotherm_out    = solve_metabolic_rate(organism, environment, skin_temperature, insulation_temperature)
         skin_temperature = endotherm_out.thermoregulation.skin_temperature
         insulation_temperature = endotherm_out.thermoregulation.insulation_temperature
-        generated_heat_flow = endotherm_out.energy_flows.generated_heat_flow
+        metabolic_heat_flow = endotherm_out.energy_flows.metabolic_heat_flow
     end
 
     return endotherm_out

--- a/src/endotherm/thermoregulation/rulebased.jl
+++ b/src/endotherm/thermoregulation/rulebased.jl
@@ -106,21 +106,21 @@ end
 
 Allow core temperature to rise (hyperthermia).
 
-Returns updated `SteppedParameter`, new Q_minimum, and `organism`.
+Returns updated `SteppedParameter`, new minimum_heat_flow, and `organism`.
 """
 function hyperthermia(organism::Organism, core_temperature_limits::SteppedParameter, pant_cost)
-    Q_minimum_ref = thermoregulation(organism).Q_minimum_ref
+    minimum_heat_flow = thermoregulation(organism).minimum_heat_flow
     core_temp = min(core_temperature_limits.current + core_temperature_limits.step, core_temperature_limits.max)
     core_temperature_limits = @set core_temperature_limits.current = core_temp
 
     metabolism = HeatExchange.metabolism_pars(organism)
-    Q_minimum = (Q_minimum_ref + pant_cost) *
+    minimum_heat_flow = (minimum_heat_flow + pant_cost) *
                 q10_scale(metabolism.q10, core_temp, core_temperature_limits.reference)
 
     organism = @set organism.traits.heat_exchange.metabolism_pars.core_temperature = core_temp
-    organism = @set organism.traits.heat_exchange.metabolism_pars.metabolic_heat_flow = Q_minimum
+    organism = @set organism.traits.heat_exchange.metabolism_pars.metabolic_heat_flow = minimum_heat_flow
 
-    return core_temperature_limits, Q_minimum, organism
+    return core_temperature_limits, minimum_heat_flow, organism
 end
 
 """
@@ -128,27 +128,27 @@ end
 
 Increase panting rate for evaporative cooling.
 
-Returns updated `PantingLimits`, new Q_minimum, and `organism`.
+Returns updated `PantingLimits`, new minimum_heat_flow, and `organism`.
 """
 function pant(organism::Organism, panting_limits::PantingLimits)
-    Q_minimum_ref = thermoregulation(organism).Q_minimum_ref
+    minimum_heat_flow = thermoregulation(organism).minimum_heat_flow
     pant_rate_limits = panting_limits.pant
     pant_rate = min(pant_rate_limits.current + pant_rate_limits.step, pant_rate_limits.max)
 
     pant_cost = ((pant_rate - 1) / (pant_rate_limits.max + 1e-6 - 1)) *
-                (panting_limits.multiplier - 1) * Q_minimum_ref
+                (panting_limits.multiplier - 1) * minimum_heat_flow
 
     panting_limits = @set panting_limits.pant.current = pant_rate
     panting_limits = @set panting_limits.cost = pant_cost
 
     metabolism = HeatExchange.metabolism_pars(organism)
-    Q_minimum = (Q_minimum_ref + pant_cost) *
+    minimum_heat_flow = (minimum_heat_flow + pant_cost) *
                 q10_scale(metabolism.q10, metabolism.core_temperature, panting_limits.core_temperature_ref)
 
-    organism = @set organism.traits.heat_exchange.metabolism_pars.metabolic_heat_flow = Q_minimum
+    organism = @set organism.traits.heat_exchange.metabolism_pars.metabolic_heat_flow = minimum_heat_flow
     organism = @set organism.traits.heat_exchange.respiration_pars.pant = pant_rate
 
-    return panting_limits, Q_minimum, organism
+    return panting_limits, minimum_heat_flow, organism
 end
 
 """
@@ -228,11 +228,11 @@ function thermoregulate(
     insulation_temperature = endotherm_out.thermoregulation.insulation_temperature
     metabolic_heat_flow = endotherm_out.energy_flows.metabolic_heat_flow
 
-    Q_minimum = limits.Q_minimum_ref
+    minimum_heat_flow = limits.minimum_heat_flow
 
     iteration = 0
 
-    while metabolic_heat_flow < Q_minimum * (1 - tolerance)
+    while metabolic_heat_flow < minimum_heat_flow * (1 - tolerance)
         iteration += 1
         if iteration > max_iterations
             @warn "max_iterations exceeded"
@@ -251,11 +251,11 @@ function thermoregulate(
             flesh_conductivity_limits, organism = vasodilate(organism, flesh_conductivity_limits)
 
         elseif core_temperature_limits.current < core_temperature_limits.max
-            core_temperature_limits, Q_minimum, organism = hyperthermia(
+            core_temperature_limits, minimum_heat_flow, organism = hyperthermia(
                 organism, core_temperature_limits, panting_limits.cost
             )
             if simultaneous_pant(mode) && panting_limits.pant.current < panting_limits.pant.max
-                panting_limits, Q_minimum, organism = pant(organism, panting_limits)
+                panting_limits, minimum_heat_flow, organism = pant(organism, panting_limits)
             end
             if simultaneous_sweat(mode)
                 if (skin_wetness_limits.current > skin_wetness_limits.max) ||
@@ -267,7 +267,7 @@ function thermoregulate(
             end
 
         elseif panting_limits.pant.current < panting_limits.pant.max
-            panting_limits, Q_minimum, organism = pant(organism, panting_limits)
+            panting_limits, minimum_heat_flow, organism = pant(organism, panting_limits)
             if simultaneous_sweat(mode)
                 if (skin_wetness_limits.current > skin_wetness_limits.max) ||
                    (skin_wetness_limits.step <= 0)

--- a/src/endotherm/thermoregulation/shared.jl
+++ b/src/endotherm/thermoregulation/shared.jl
@@ -34,7 +34,7 @@ simultaneous_sweat(::CorePantingSweatingFirst) = true
 # ----------------------------------------------------------------------------
 
 """
-    thermoregulate(organism, environment, generated_heat_flow, skin_temperature,
+    thermoregulate(organism, environment, metabolic_heat_flow, skin_temperature,
                    insulation_temperature)
 
 Run the thermoregulation loop to find heat balance.
@@ -46,7 +46,7 @@ Dispatches on the organism's thermal strategy (`Endotherm`, `Ectotherm`,
 function thermoregulate(
     organism::Organism,
     environment::NamedTuple,
-    generated_heat_flow,
+    metabolic_heat_flow,
     skin_temperature,
     insulation_temperature,
 )
@@ -54,7 +54,7 @@ function thermoregulate(
         thermal_strategy(organism),
         organism,
         environment,
-        generated_heat_flow,
+        metabolic_heat_flow,
         skin_temperature,
         insulation_temperature,
     )
@@ -64,7 +64,7 @@ function thermoregulate(
     ::Endotherm,
     organism::Organism,
     environment::NamedTuple,
-    generated_heat_flow,
+    metabolic_heat_flow,
     skin_temperature,
     insulation_temperature,
 )
@@ -73,7 +73,7 @@ function thermoregulate(
         control_strategy(organism),
         organism,
         environment,
-        generated_heat_flow,
+        metabolic_heat_flow,
         skin_temperature,
         insulation_temperature,
     )
@@ -83,7 +83,7 @@ function thermoregulate(
     ::Heterotherm,
     organism::Organism,
     environment::NamedTuple,
-    generated_heat_flow,
+    metabolic_heat_flow,
     skin_temperature,
     insulation_temperature,
 )
@@ -111,17 +111,17 @@ q10_scale(q10, T::Unitful.Quantity, T_reference::Unitful.Quantity) =
 # ----------------------------------------------------------------------------
 
 """
-    rebuild_body(shape, fur::Fur, fat) -> Body
+    rebuild_body(shape, fur::FibrousLayer, fat) -> Body
     rebuild_body(shape, fur_depth, fur_diameter, fur_density, fat) -> Body
 
 Construct a `Body` from a shape, a fur insulation layer, and a fat layer.
-The 5-argument form constructs the `Fur` from its primitive fields. Used by
+The 5-argument form constructs the `FibrousLayer` from its primitive fields. Used by
 rule-based effectors that mutate the organism (`piloerect`, `uncurl`) and by
 IPOPT to build trial bodies inside the residual function.
 """
-rebuild_body(shape, fur::Fur, fat) = Body(shape, CompositeInsulation(fur, fat))
+rebuild_body(shape, fur::FibrousLayer, fat) = Body(shape, CompositeInsulation(fur, fat))
 rebuild_body(shape, fur_depth, fur_diameter, fur_density, fat) =
-    rebuild_body(shape, Fur(fur_depth, fur_diameter, fur_density), fat)
+    rebuild_body(shape, FibrousLayer(fur_depth, fur_diameter, fur_density), fat)
 
 # ----------------------------------------------------------------------------
 # Initial state for the inner physiological thermoregulate
@@ -129,7 +129,7 @@ rebuild_body(shape, fur_depth, fur_diameter, fur_density, fat) =
 
 """
     initial_physiological_state(organism, environment_vars) ->
-        (; generated_heat_flow, skin_temperature, insulation_temperature)
+        (; metabolic_heat_flow, skin_temperature, insulation_temperature)
 
 Standard initial guesses for the inner physiological thermoregulate loop:
 no pre-assumed metabolic heat, skin 3 K below the setpoint core temperature,
@@ -137,7 +137,7 @@ and insulation surface at air temperature.
 """
 function initial_physiological_state(organism::Organism, environment_vars)
     (;
-        generated_heat_flow    = zero(thermoregulation(organism).Q_minimum_ref),
+        metabolic_heat_flow    = zero(thermoregulation(organism).Q_minimum_ref),
         skin_temperature       = HeatExchange.metabolism_pars(organism).core_temperature - 3u"K",
         insulation_temperature = environment_vars.air_temperature,
     )

--- a/src/endotherm/thermoregulation/shared.jl
+++ b/src/endotherm/thermoregulation/shared.jl
@@ -95,16 +95,16 @@ end
 # ----------------------------------------------------------------------------
 
 """
-    q10_scale(q10, T, T_reference) -> Real
+    q10_scale(q10, temperature, reference_temperature) -> Real
 
-Q10 metabolic-rate multiplier: `q10 ^ ((T − T_reference) / 10)`.
+Q10 metabolic-rate multiplier: `q10 ^ ((temperature − reference_temperature) / 10)`.
 
 Inputs must be Unitful temperatures. Scientific code in this package never
 operates on stripped temperatures; if a caller has Float64 K it has crossed
 a unit boundary it shouldn't have crossed.
 """
-q10_scale(q10, T::Unitful.Quantity, T_reference::Unitful.Quantity) =
-    q10 ^ (ustrip(u"K", T - T_reference) / 10)
+q10_scale(q10, temperature::Unitful.Quantity, reference_temperature::Unitful.Quantity) =
+    q10 ^ (ustrip(u"K", temperature - reference_temperature) / 10)
 
 # ----------------------------------------------------------------------------
 # Body reconstruction helper
@@ -137,7 +137,7 @@ and insulation surface at air temperature.
 """
 function initial_physiological_state(organism::Organism, environment_vars)
     (;
-        metabolic_heat_flow    = zero(thermoregulation(organism).Q_minimum_ref),
+        metabolic_heat_flow    = zero(thermoregulation(organism).minimum_heat_flow),
         skin_temperature       = HeatExchange.metabolism_pars(organism).core_temperature - 3u"K",
         insulation_temperature = environment_vars.air_temperature,
     )

--- a/src/organism.jl
+++ b/src/organism.jl
@@ -66,7 +66,7 @@ metabolic cost and effectiveness.
 
 # Fields
 - `mode::M`: Thermoregulation mode (`CoreFirst`, `CoreAndPantingFirst`, or `CorePantingSweatingFirst`).
-- `tolerance::T`: Fraction below Q_minimum allowed
+- `tolerance::T`: Fraction below minimum_heat_flow allowed
 - `max_iterations::I`: Maximum iterations before warning
 """
 Base.@kwdef struct RuleBasedSequentialControl{M<:AbstractThermoregulationMode,T,I} <: AbstractControlStrategy
@@ -81,13 +81,20 @@ end
 IPOPT-based nonlinear programming control strategy.
 
 Solves the thermoregulation problem as a constrained optimisation:
-minimise deviation from the setpoint core temperature subject to three
-heat-balance equality constraints, with all physiological effectors
-(flesh_conductivity, pant, skin_wetness) as continuous decision variables.
+minimise deviation from the setpoint core temperature subject to heat-balance
+equality constraints, with all physiological effectors (flesh_conductivity,
+pant, skin_wetness) as continuous decision variables.
+
+# Fields
+- `nlp_strategy`: NLP formulation — `WeightedMeanNLP()` (default, dorsal/ventral
+  weighted-mean single body, 9 variables, 4 constraints) or `MultiSidedNLP()`
+  (explicit per-side heat balance, 11 variables, 7 constraints).
 
 Requires `Optimization.jl` and `OptimizationIpopt.jl`.
 """
-struct IPOPTControl <: AbstractControlStrategy end
+Base.@kwdef struct IPOPTControl <: AbstractControlStrategy
+    nlp_strategy::HeatExchange.NLPStrategy = HeatExchange.WeightedMeanNLP()
+end
 
 # =============================================================================
 # Behavior Types
@@ -145,19 +152,19 @@ Abstract supertype for the instantaneous activity state of an organism.
 
 Concrete subtypes mirror NicheMapR's `ACT` output column:
 - [`Resting`](@ref) — underground or thermally unable to be active (ACT = 0)
-- [`Basking`](@ref) — above ground, warming up; `T_bask_min ≤ core_temperature < T_active_min` (ACT = 1)
+- [`Basking`](@ref) — above ground, warming up; `basking_temperature_min ≤ core_temperature < active_temperature_min` (ACT = 1)
 - [`Active`](@ref) — above ground, within activity thermal window;
-  `T_active_min ≤ core_temperature ≤ T_active_max` (ACT = 2)
+  `active_temperature_min ≤ core_temperature ≤ active_temperature_max` (ACT = 2)
 """
 abstract type OrganismState end
 
 "Resting state: underground or outside the thermal window for surface activity."
 struct Resting <: OrganismState end
 
-"Basking state: above ground but below `T_active_min`; warming toward activity temperature."
+"Basking state: above ground but below `active_temperature_min`; warming toward activity temperature."
 struct Basking <: OrganismState end
 
-"Active state: above ground within the activity thermal window `[T_active_min, T_active_max]`."
+"Active state: above ground within the activity thermal window `[active_temperature_min, active_temperature_max]`."
 struct Active <: OrganismState end
 
 """

--- a/test/ectotherm.jl
+++ b/test/ectotherm.jl
@@ -77,7 +77,7 @@ using CSV, DataFrames
         )
         (
             solar_radiation           = (zenith_angle = met_df.ZEN .* u"°",),
-            pressure                  = fill(atmospheric_pressure(elevation), n),
+            pressure                  = fill(FluidProperties.atmospheric_pressure(elevation), n),
             profile                   = profile,
             sky_temperature           = (met_df.TSKYC .+ 273.15) .* u"K",
             soil_temperature          = soil_T,
@@ -159,13 +159,13 @@ using CSV, DataFrames
                 absorptivity_min        = 0.6,         # R: alpha_min=0.6
                 absorptivity_max        = 0.9,         # R: alpha_max=0.9
                 absorptivity_step       = 0.003,
-                T_active_min            = u"K"(24.0u"°C"),  # R: T_F_min=24
-                T_active_max            = u"K"(34.0u"°C"),  # R: T_F_max=34
-                T_bask_min              = u"K"(17.5u"°C"),  # R: T_B_min=17.5
-                T_emerge_min            = u"K"(15.0u"°C"),  # R: T_RB_min=15
-                T_target                = u"K"(30.0u"°C"),  # R: T_pref=30
-                T_critical_min          = u"K"(6.0u"°C"),   # R: CT_min=6
-                T_critical_max          = u"K"(40.0u"°C"),  # R: CT_max=40
+                active_temperature_min   = u"K"(24.0u"°C"),  # R: T_F_min=24
+                active_temperature_max   = u"K"(34.0u"°C"),  # R: T_F_max=34
+                basking_temperature_min  = u"K"(17.5u"°C"),  # R: T_B_min=17.5
+                emerge_temperature_min   = u"K"(15.0u"°C"),  # R: T_RB_min=15
+                target_temperature       = u"K"(30.0u"°C"),  # R: T_pref=30
+                critical_temperature_min = u"K"(6.0u"°C"),   # R: CT_min=6
+                critical_temperature_max = u"K"(40.0u"°C"),  # R: CT_max=40
                 heat_exchange           = common_heat_exchange,
             )
             organism = Organism(body, organism_traits)
@@ -192,9 +192,9 @@ using CSV, DataFrames
             core_temperature_C = [ustrip(u"°C", r.core_temperature) for r in results]
             state       = [r.state                  for r in results]
             julia_act   = [s isa Active ? 2 : s isa Basking ? 1 : 0 for s in state]
-            jl_Q_solar  = [ustrip(u"W", r.ectotherm_out.energy_balance.solar_flow)        for r in results]
-            jl_Q_ir_in  = [ustrip(u"W", r.ectotherm_out.energy_balance.longwave_flow_in)  for r in results]
-            jl_Q_ir_out = [ustrip(u"W", r.ectotherm_out.energy_balance.longwave_flow_out) for r in results]
+            julia_solar_flow  = [ustrip(u"W", r.ectotherm_out.energy_balance.solar_flow)        for r in results]
+            julia_longwave_in  = [ustrip(u"W", r.ectotherm_out.energy_balance.longwave_flow_in)  for r in results]
+            julia_longwave_out = [ustrip(u"W", r.ectotherm_out.energy_balance.longwave_flow_out) for r in results]
 
             # NicheMapR reference
             scen_dir = joinpath(@__DIR__, "data", "ectotherm", scen.name)
@@ -209,9 +209,9 @@ using CSV, DataFrames
 
             # Heat fluxes: same NMR microclimate input; solar ~0.35 W RMSE from absorptivity
             # differences between Julia and NicheMapR colour-change algorithms
-            @test rmse(jl_Q_solar,  r_eb.QSOL)   < 0.5
-            @test rmse(jl_Q_ir_in,  r_eb.QIRIN)  < 0.3
-            @test rmse(jl_Q_ir_out, r_eb.QIROUT) < 0.3
+            @test rmse(julia_solar_flow,  r_eb.QSOL)   < 0.5
+            @test rmse(julia_longwave_in,  r_eb.QIRIN)  < 0.3
+            @test rmse(julia_longwave_out, r_eb.QIROUT) < 0.3
         end
     end
 

--- a/test/endotherm.jl
+++ b/test/endotherm.jl
@@ -42,11 +42,11 @@ for shape_number in 1:4
                 (endo_input.SHAPE_B), (endo_input.SHAPE_C))
         end
 
-        fat = Fat(endo_input.FATPCT / 100.0, (endo_input.FATDEN)u"kg/m^3")
+        fat = FatLayer(endo_input.FATPCT / 100.0, (endo_input.FATDEN)u"kg/m^3")
         mean_insulation_depth = (endo_input.ZFURD * (1 - endo_input.PVEN) + endo_input.ZFURV * endo_input.PVEN)u"m"
         mean_fibre_diameter = (endo_input.DHAIRD * (1 - endo_input.PVEN) + endo_input.DHAIRV * endo_input.PVEN)u"m"
         mean_fibre_density = (endo_input.RHOD * (1 - endo_input.PVEN) + endo_input.RHOV * endo_input.PVEN)u"1/m^2"
-        fur = Fur(mean_insulation_depth, mean_fibre_diameter, mean_fibre_density)
+        fur = FibrousLayer(mean_insulation_depth, mean_fibre_diameter, mean_fibre_density)
         geometry = Body(shape_pars, CompositeInsulation(fur, fat))
 
         environment_vars = EnvironmentalVars(;
@@ -182,7 +182,7 @@ for shape_number in 1:4
         skin_temperature = u"K"((endo_input.TS)u"°C")
         insulation_temperature = u"K"((endo_input.TFA)u"°C")
         Q_minimum_ref = (endo_input.QBASAL)u"W"
-        generated_heat_flow = 0.0u"W"
+        metabolic_heat_flow = 0.0u"W"
         core_temperature_ref = metabolism_pars.core_temperature
 
         treg_mode = endo_input.TREGMODE == 1 ? CoreFirst() :
@@ -255,7 +255,7 @@ for shape_number in 1:4
         endotherm_out = thermoregulate(
             organism,
             environment,
-            generated_heat_flow,
+            metabolic_heat_flow,
             skin_temperature,
             insulation_temperature,
         )
@@ -273,13 +273,13 @@ for shape_number in 1:4
         @testset "endotherm thermoregulation comparisons" begin
             @test treg_output_vec.TC ≈ ustrip(u"°C", thermoregulation.core_temperature) rtol = rtol
             @test treg_output_vec.TLUNG ≈ ustrip(u"°C", thermoregulation.lung_temperature) rtol = rtol
-            @test treg_output_vec.TSKIN_D ≈ ustrip(u"°C", thermoregulation.skin_temperature_dorsal) rtol = rtol
-            @test treg_output_vec.TSKIN_V ≈ ustrip(u"°C", thermoregulation.skin_temperature_ventral) rtol = rtol
-            @test treg_output_vec.TFA_D ≈ ustrip(u"°C", thermoregulation.insulation_temperature_dorsal) rtol = rtol
-            @test treg_output_vec.TFA_V ≈ ustrip(u"°C", thermoregulation.insulation_temperature_ventral) rtol = rtol
+            @test treg_output_vec.TSKIN_D ≈ ustrip(u"°C", thermoregulation.dorsal.skin_temperature) rtol = rtol
+            @test treg_output_vec.TSKIN_V ≈ ustrip(u"°C", thermoregulation.ventral.skin_temperature) rtol = rtol
+            @test treg_output_vec.TFA_D ≈ ustrip(u"°C", thermoregulation.dorsal.insulation_temperature) rtol = rtol
+            @test treg_output_vec.TFA_V ≈ ustrip(u"°C", thermoregulation.ventral.insulation_temperature) rtol = rtol
             if insulation_test > 0.0u"m"
-                @test treg_output_vec.K_FUR_D ≈ ustrip(u"W/m/K", thermoregulation.insulation_conductivity_dorsal) rtol = rtol
-                @test treg_output_vec.K_FUR_V ≈ ustrip(u"W/m/K", thermoregulation.insulation_conductivity_ventral) rtol = rtol
+                @test treg_output_vec.K_FUR_D ≈ ustrip(u"W/m/K", thermoregulation.dorsal.insulation_conductivity) rtol = rtol
+                @test treg_output_vec.K_FUR_V ≈ ustrip(u"W/m/K", thermoregulation.ventral.insulation_conductivity) rtol = rtol
             end
             if isnothing(insulation_conductivity)
                 @test treg_output_vec.K_FUR_EFF ≈ ustrip(u"W/m/K", thermoregulation.insulation_conductivity_effective) rtol = rtol
@@ -330,7 +330,7 @@ for shape_number in 1:4
         @testset "endotherm energy flux comparisons" begin
             @test enbal_output_vec.QSOL ≈ ustrip(u"W", energy_fluxes.solar_flow) rtol = rtol
             @test enbal_output_vec.QIRIN ≈ ustrip(u"W", energy_fluxes.longwave_flow_in) rtol = rtol
-            @test enbal_output_vec.QGEN ≈ ustrip(u"W", energy_fluxes.generated_heat_flow) rtol = rtol
+            @test enbal_output_vec.QGEN ≈ ustrip(u"W", energy_fluxes.metabolic_heat_flow) rtol = rtol
             @test QEVAP ≈ ustrip(u"W", energy_fluxes.evaporation_heat_flow) rtol = rtol
             @test enbal_output_vec.QIROUT ≈ ustrip(u"W", energy_fluxes.longwave_flow_out) rtol = rtol
             @test enbal_output_vec.QCONV ≈ ustrip(u"W", energy_fluxes.convection_heat_flow) rtol = rtol
@@ -342,7 +342,7 @@ for shape_number in 1:4
             if metabolic_rate_options.respire
                 @test masbal_output_vec.AIR_L ≈ ustrip(u"L/hr", mass_fluxes.air_flow) rtol = rtol
                 @test masbal_output_vec.O2_L ≈ ustrip(u"L/hr", mass_fluxes.oxygen_flow_standard) rtol = rtol
-                @test masbal_output_vec.H2OResp_g ≈ ustrip(u"g/hr", mass_fluxes.respiration_mass) rtol = rtol
+                @test masbal_output_vec.H2OResp_g ≈ ustrip(u"g/hr", mass_fluxes.respiration_mass_flow) rtol = rtol
                 @test masbal_output_vec.H2OCut_g ≈ ustrip(u"g/hr", mass_fluxes.m_sweat) rtol = rtol
                 #@test masbal_output_vec.H2O_mol_in ≈ ustrip(u"mol/hr", mass_fluxes.molar_fluxes_in.water) rtol = rtol
                 #@test masbal_output_vec.H2O_mol_out ≈ ustrip(u"mol/hr", mass_fluxes.molar_fluxes_out.water) rtol = rtol

--- a/test/endotherm.jl
+++ b/test/endotherm.jl
@@ -181,7 +181,7 @@ for shape_number in 1:4
         # initial conditions
         skin_temperature = u"K"((endo_input.TS)u"°C")
         insulation_temperature = u"K"((endo_input.TFA)u"°C")
-        Q_minimum_ref = (endo_input.QBASAL)u"W"
+        minimum_heat_flow = (endo_input.QBASAL)u"W"
         metabolic_heat_flow = 0.0u"W"
         core_temperature_ref = metabolism_pars.core_temperature
 
@@ -194,7 +194,7 @@ for shape_number in 1:4
                 tolerance=0.005,
                 max_iterations=1000,
             ),
-            Q_minimum_ref,
+            minimum_heat_flow,
             insulation=InsulationLimits(;
                 dorsal=SteppedParameter(;
                     current=insulation_pars.dorsal.depth,


### PR DESCRIPTION
Updates all code to use new names from HeatExchange and BiophysicalGeometry and use the new hooks for NLP outputs of HeatExchange which should fully remove any physics from BiophysicalBehavoiur. Still using finite diff for IPOPT.